### PR TITLE
change url in jenkins config

### DIFF
--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -28,7 +28,7 @@ pipeline {
                           extensions: [],
                           gitTool: 'Default',
                           submoduleCfg: [],
-                          userRemoteConfigs: [[url: 'https://github.com/usgs-makerspace/snow-to-flow.git']]
+                          userRemoteConfigs: [[url: 'https://github.com/usgs-vizlab/snow-to-flow.git']]
                         ])
                 }
         }


### PR DESCRIPTION
Changes made:
-----------
corrected the url for jenkins


Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
