### PR TITLE
Reusable sections

### DIFF
--- a/src/components/TestFigure.vue
+++ b/src/components/TestFigure.vue
@@ -1,0 +1,52 @@
+<template>
+  <!---VizSection-->
+  <VizSection id="firstSection">
+    <!-- TAKEAWAY TITLE -->
+    <template v-slot:takeAway>
+      <h1>Take Away Title</h1>
+    </template>
+    <!-- FIGURES -->
+    <template v-slot:figures>
+      <div class="single maxWidth">
+        <figure>Large Figure 1</figure>
+      </div>
+      <div class="group three">
+        <figure>Figure 1</figure>
+        <figure>Figure 2</figure>
+        <figure>Figure 3</figure>
+        <figure>Figure 4</figure>
+      </div>
+      <div class="group two maxWidth">
+        <figure>Figure 5</figure>
+        <figure>Figure 6</figure>
+        <figure>Figure 7</figure>
+        <figure>Figure 8</figure>
+      </div>
+      <div class="single">
+        <figure>Large Figure 2</figure>
+      </div>
+    </template>
+    <!-- FIGURE CAPTION -->
+    <template v-slot:figureCaption>
+      <p>
+        Figure 1. Mean weight of two species of ground squirrels prior to and following hibernation
+      </p>
+    </template>
+    <!-- EXPLANATION -->
+    <template v-slot:explanation>
+      <p>Stuff to explain.</p>
+    </template>
+  </VizSection>
+</template>
+<script>
+import VizSection from '@/components/VizSection';
+export default {
+    name: "Test",
+    components:{
+        VizSection
+    }
+}
+</script>
+<style lang="sass" scoped>
+
+</style>

--- a/src/components/VizSection.vue
+++ b/src/components/VizSection.vue
@@ -1,0 +1,85 @@
+<template>
+  <section class="vizSection">
+    <div class="takeAway">
+      <slot name="takeAway">
+        Take Away Title
+      </slot>
+    </div>
+    <div class="figures">
+      <slot name="figures">
+        Figure(s)
+      </slot>
+    </div>
+    <div class="figureCaption maxWidth">
+      <slot name="figureCaption">
+        Figure Caption
+      </slot>
+    </div>
+    <div class="explanation maxWidth">
+      <slot name="explanation">
+        Explanation
+      </slot>
+    </div>
+  </section>
+</template>
+<script>
+export default {
+    name: "VizSection"
+}
+</script>
+<style scoped lang="scss">
+$spacing: 15px;
+$border: 1px solid #000;
+.vizSection{
+    padding: 10px;
+    p{
+        padding: 0; 
+        margin: 0;
+    }
+}
+.takeAway{
+    h1{
+        text-align: center;
+    }
+    margin-bottom: $spacing;
+}
+.figures{
+    &>*{
+        margin-bottom: $spacing;
+    }
+    figure{
+        border: $border;
+    }
+}
+.maxWidth{
+    max-width: 1500px;
+    margin: 0 auto 15px auto;
+}
+.single{
+    width: 100%;
+    figure{
+        min-height: 300px;
+    }
+}
+.group{
+    figure{
+        margin-bottom: $spacing;
+    }
+}
+.figureCaption{
+    margin-bottom: $spacing;
+}
+
+@media screen and (min-width: 1024px){
+    .group{
+        display: grid;
+        gap: 15px;
+    }
+    .two{
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .three{
+        grid-template-columns: repeat(3, 1fr);
+    }   
+}
+</style>

--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -1,16 +1,11 @@
 <template>
-  <div id="visualization">
-    <Test />
-  </div>
+  <div id="visualization" />
 </template>
 
 <script>
    import Test from '@/components/TestFigure';
     export default {
         name: 'Visualization',
-        components: {
-          Test
-        }
     }
 </script>
 

--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -1,20 +1,15 @@
 <template>
-  <div id="visualization" />
+  <div id="visualization">
+    <Test />
+  </div>
 </template>
 
 <script>
-   
+   import Test from '@/components/TestFigure';
     export default {
         name: 'Visualization',
         components: {
-          // Timing: () => import(/* webpackPreload: true */ /*webpackChunkName: "intro"*/ "@/components/Timing"),
-          // Splash: () => import(/* webpackPreload: true */ /*webpackChunkName: "Header"*/ "@/components/Splash"),
-          // // SWE: () => import(/* webpackPreload: true */ /*webpackChunkName: "swe"*/ "./swe/SWE"),
-          // SWEanimation: () => import(/* webpackPreload: true */ /*webpackChunkName: "swea"*/ "@/components/SWEanimation"),
-          // //In2021: () => import(/* webpackPreload: true */ /*webpackChunkName: "In2021"*/ "./in2021/In2021"),
-          // // Intro: () => import(/* webpackPreload: true */ /*webpackChunkName: "intro"*/ "./intro/Intro"),
-          // Broadscale: () => import(/* webpackPreload: true */ /*webpackChunkName: "broadscale"*/ "@/components/Broadscale"),
-          // References: () => import(/* webpackPreload: true */ /*webpackChunkName: "references"*/ "@/components/References"), 
+          Test
         }
     }
 </script>

--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -3,7 +3,6 @@
 </template>
 
 <script>
-   import Test from '@/components/TestFigure';
     export default {
         name: 'Visualization',
     }


### PR DESCRIPTION
Changes made:
-----------
Description

First Cut of a customizable dynamic Viz section template

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
