### PR TITLE
CSS changes

### DIFF
--- a/src/components/References.vue
+++ b/src/components/References.vue
@@ -51,9 +51,10 @@
         }
     }
 </script>
-
+/*Scope USWDS styles*/
+<style scoped src="../../node_modules/uswds/dist/css/uswds.min.css" />
 <style scoped lang="scss">
-@import "~uswds/dist/css/uswds.min.css";
+// @import "~uswds/dist/css/uswds.min.css";
 /*https://css-tricks.com/creating-a-maintainable-icon-system-with-sass/ icon system code */
 $icons:(
   "chevronLeft": '<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 165 255"><path d="M165,36v4c-1.78,2.17-3.4,4.52-5.38,6.5q-38.06,38.16-76.18,76.25c-1.48,1.48-2.85,3.08-4.46,4.83,1.73,1.82,3.06,3.28,4.45,4.67q38.1,38.13,76.19,76.25c2,2,3.6,4.33,5.38,6.5v4c-1.55,2.12-2.86,4.47-4.68,6.32Q147.78,238.13,135,250.67a48.26,48.26,0,0,1-6,4.33h-4a78.69,78.69,0,0,1-7-5.58Q62.55,194.07,7.18,138.6C4.71,136.14,2.39,133.54,0,131v-7c1.57-1.71,3.07-3.49,4.71-5.13Q61.51,62,118.4,5.22A70.08,70.08,0,0,1,125,0h5q16.42,16.11,32.81,32.25C163.8,33.24,164.28,34.74,165,36Z" style="fill:%%COLOR%%"/></svg>',
@@ -94,12 +95,22 @@ button:not([disabled]):focus{
   background-size: 15px 10px;
   background-color: $brightBlue;
   color: white;
+  &:hover{
+    //overides USWDS styles
+    background-color: $brightBlue;
+    color: white;
+  }
 }
 .usa-accordion__button[aria-expanded=false]{
   background-image: get-icon("chevronLeft", $brightBlue);
   background-size: 10px 15px;
   background-color: rgb(241, 240, 240);
   color: $brightBlue;
+  &:hover{
+    background-image: get-icon("chevronLeft", #fff);
+    background-color: $brightBlue;
+    color: white;
+  }
 }
 .target p{
   padding: 0;

--- a/src/components/References.vue
+++ b/src/components/References.vue
@@ -52,9 +52,9 @@
     }
 </script>
 /*Scope USWDS styles*/
-<style scoped src="../../node_modules/uswds/dist/css/uswds.min.css" />
+<style scoped src="../../node_modules/uswds/dist/css/uswds.min.css"></style>
 <style scoped lang="scss">
-// @import "~uswds/dist/css/uswds.min.css";
+
 /*https://css-tricks.com/creating-a-maintainable-icon-system-with-sass/ icon system code */
 $icons:(
   "chevronLeft": '<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 165 255"><path d="M165,36v4c-1.78,2.17-3.4,4.52-5.38,6.5q-38.06,38.16-76.18,76.25c-1.48,1.48-2.85,3.08-4.46,4.83,1.73,1.82,3.06,3.28,4.45,4.67q38.1,38.13,76.19,76.25c2,2,3.6,4.33,5.38,6.5v4c-1.55,2.12-2.86,4.47-4.68,6.32Q147.78,238.13,135,250.67a48.26,48.26,0,0,1-6,4.33h-4a78.69,78.69,0,0,1-7-5.58Q62.55,194.07,7.18,138.6C4.71,136.14,2.39,133.54,0,131v-7c1.57-1.71,3.07-3.49,4.71-5.13Q61.51,62,118.4,5.22A70.08,70.08,0,0,1,125,0h5q16.42,16.11,32.81,32.25C163.8,33.24,164.28,34.74,165,36Z" style="fill:%%COLOR%%"/></svg>',

--- a/src/components/SNTLmap.vue
+++ b/src/components/SNTLmap.vue
@@ -17,46 +17,46 @@
             <p>Pepper jack melted cheese feta. Cheesy grin taleggio fromage edam boursin manchego cheese triangles parmesan. Fromage cheese and biscuits say cheese bocconcini gouda lancashire cheese slices ricotta. Rubber cheese melted cheese cheesy grin everyone loves mascarpone.</p>
             <Sidebar />
             <div id="toggle-container">
-            <h3 id="sntl-name">
-              Show snow:
-            </h3>
-            <form
-              id="showData"
-              align="left"
-            >
-              <input
-                id="inch_2020"
-                v-model="sntl_variable"
-                type="radio"
+              <h3 id="sntl-name">
+                Show snow:
+              </h3>
+              <form
+                id="showData"
                 align="left"
-                value="Percent_of_POR_Median"
-                @change="setColor()"
-              ><label for="inch_2020"> Percent of POR Median</label><br>
-              <input
-                id="inch_POR"
-                v-model="sntl_variable"
-                type="radio"
-                align="left"
-                value="Percent_of_Median_Water_Year_Peak_POR"
-                @change="setColor()"
-              ><label for="inch_POR"> Percent of Water Year Peak POR</label><br>
-              <input
-                id="inch_diff"
-                v-model="sntl_variable"
-                type="radio"
-                align="left"
-                value="POR_Median_Departure_inches"
-                @change="setColor()"
-              ><label for="inch_diff"> Snow anomaly (inch difference)</label>
-            </form>
-          </div>
+              >
+                <input
+                  id="inch_2020"
+                  v-model="sntl_variable"
+                  type="radio"
+                  align="left"
+                  value="Percent_of_POR_Median"
+                  @change="setColor()"
+                ><label for="inch_2020"> Percent of POR Median</label><br>
+                <input
+                  id="inch_POR"
+                  v-model="sntl_variable"
+                  type="radio"
+                  align="left"
+                  value="Percent_of_Median_Water_Year_Peak_POR"
+                  @change="setColor()"
+                ><label for="inch_POR"> Percent of Water Year Peak POR</label><br>
+                <input
+                  id="inch_diff"
+                  v-model="sntl_variable"
+                  type="radio"
+                  align="left"
+                  value="POR_Median_Departure_inches"
+                  @change="setColor()"
+                ><label for="inch_diff"> Snow anomaly (inch difference)</label>
+              </form>
+            </div>
           </div>
           <div
             id="ak"
             class="map-container"
           >
-        <!-- the y dimension was edited outside of R -->
-        <!-- because this is 2/3 the width of conus and they are drawn on the same pixel scale, grid needs to allocate 2/3 page widtrh to conus -->
+            <!-- the y dimension was edited outside of R -->
+            <!-- because this is 2/3 the width of conus and they are drawn on the same pixel scale, grid needs to allocate 2/3 page widtrh to conus -->
             <svg
               id="ak-sntl"
               xmlns="http://www.w3.org/2000/svg"
@@ -89,7 +89,7 @@
             </svg>
           </div>
         </div>
-        <div  id="grid-right">
+        <div id="grid-right">
           <div
             id="usa"
             class="map-container"
@@ -1592,9 +1592,6 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-.map-grid {
-  max-height: 80vh;
-}
 //map style
 line, polyline, polygon, path, rect, circle {
       fill: none;


### PR DESCRIPTION
Changes made:
-----------
Description

Apologies for my confusing linter, it looks like I messed with your SNTLmap code, but all it did was rearrange the formatting.  What I did do is remove the **max-height** on **.map-grid** as it was causing the sections text to creep up and overlap the figure.  Removing that prevents that from happening. I'll provide screen shots.   I checked it out and it still looked like it was supposed to, let me know if this is a disastrous idea.

The extra scroll bar was from me globally importing the USWDS css like an idiot.  It is now scoped to just the Reference component and it will no longer be adding scroll bars like it wants to.

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
