### PR TITLE
Touchup

### DIFF
--- a/src/components/Elevation.vue
+++ b/src/components/Elevation.vue
@@ -7,8 +7,8 @@
     </template>
     <!-- FIGURES -->
     <template v-slot:figures>
-      <div class="group two maxWidth">
-        <figure>
+      <div class="group maxWidth center">
+        <figure class="elevation">
           <img src="@/assets/maps/rayrender.png">
         </figure>
         <!--       <figure>Figure 6</figure>
@@ -37,6 +37,8 @@ export default {
     }
 }
 </script>
-<style lang="sass" scoped>
-
+<style lang="scss" scoped>
+.elevation{
+  max-width: 730px;
+}
 </style>

--- a/src/components/SNTLmap.vue
+++ b/src/components/SNTLmap.vue
@@ -6,49 +6,48 @@
       <h2>The timing and magnitude of snowmelt is changing across the western U.S.</h2>
     </template>    
     <!-- EXPLANATION -->
-    <template v-slot:explanation>
+    <template v-slot:aboveExplanation>
       <p>Pepper jack melted cheese feta. Cheesy grin taleggio fromage edam boursin manchego cheese triangles parmesan. Fromage cheese and biscuits say cheese bocconcini gouda lancashire cheese slices ricotta. Rubber cheese melted cheese cheesy grin everyone loves mascarpone.</p>
+      <Sidebar />
     </template>
     <!-- FIGURES -->
     <template v-slot:figures>
       <div class="two group map-grid">
         <div id="grid-left">
           <div id="sntl-text">
-            <p>Pepper jack melted cheese feta. Cheesy grin taleggio fromage edam boursin manchego cheese triangles parmesan. Fromage cheese and biscuits say cheese bocconcini gouda lancashire cheese slices ricotta. Rubber cheese melted cheese cheesy grin everyone loves mascarpone.</p>
-            <Sidebar />
             <div id="toggle-container">
-            <h3 id="sntl-name">
-              Show snow:
-            </h3>
-            <form
-              id="showData"
-              align="left"
-            >
-              <input
-                id="inch_2020"
-                v-model="sntl_variable"
-                type="radio"
+              <h3 id="sntl-name">
+                Show snow:
+              </h3>
+              <form
+                id="showData"
                 align="left"
-                value="perd_peak"
-                @change="setColor()"
-              ><label for="inch_2020"> Peak SWE - Magnitude</label><br>
-              <input
-                id="inch_POR"
-                v-model="sntl_variable"
-                type="radio"
-                align="left"
-                value="perd_sm50"
-                @change="setColor()"
-              ><label for="inch_POR"> SM50 - Timing</label><br>
-            </form>
-          </div>
+              >
+                <input
+                  id="inch_2020"
+                  v-model="sntl_variable"
+                  type="radio"
+                  align="left"
+                  value="perd_peak"
+                  @change="setColor()"
+                ><label for="inch_2020"> Peak SWE - Magnitude</label><br>
+                <input
+                  id="inch_POR"
+                  v-model="sntl_variable"
+                  type="radio"
+                  align="left"
+                  value="perd_sm50"
+                  @change="setColor()"
+                ><label for="inch_POR"> SM50 - Timing</label><br>
+              </form>
+            </div>
           </div>
           <div
             id="ak"
             class="map-container"
           >
-        <!-- the y dimension was edited outside of R -->
-        <!-- because this is 2/3 the width of conus and they are drawn on the same pixel scale, grid needs to allocate 2/3 page widtrh to conus -->
+            <!-- the y dimension was edited outside of R -->
+            <!-- because this is 2/3 the width of conus and they are drawn on the same pixel scale, grid needs to allocate 2/3 page widtrh to conus -->
             <svg
               id="ak-sntl"
               xmlns="http://www.w3.org/2000/svg"
@@ -81,7 +80,7 @@
             </svg>
           </div>
         </div>
-        <div  id="grid-right">
+        <div id="grid-right">
           <div
             id="usa"
             class="map-container"
@@ -1434,7 +1433,7 @@
     </template>
     <!-- EXPLANATION -->
     <template v-slot:explanation>
-      <p></p>
+      <p />
       <Sidebar />
     </template>
   </VizSection>
@@ -1579,9 +1578,6 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-.map-grid {
-  max-height: 80vh;
-}
 //map style
 line, polyline, polygon, path, rect, circle {
       fill: none;

--- a/src/components/VizSection.vue
+++ b/src/components/VizSection.vue
@@ -6,6 +6,9 @@
           Take Away Title
         </slot>
       </div>
+      <div class="aboveExplanation explanation">
+        <slot name="aboveExplanation" />
+      </div>
       <div class="figures">
         <slot name="figures">
           Figure(s)
@@ -16,8 +19,8 @@
           Figure Caption
         </slot>
       </div>
-      <div class="explanation">
-        <slot name="explanation">
+      <div class="belowExplanation explanation">
+        <slot name="belowExplanation">
           Explanation
         </slot>
       </div>


### PR DESCRIPTION
Changes made:
-----------
Description

Stopped the text from overlapping the SNTL map and created an upper explanation slot for text that would need to be above the figures.  Using the explanation slot above where it shouldn't go was not working, which is cool to know as I did not know that limitation.  When you do not need the aboveExplanation just don't fill it in.  Shouldn't mess with the layout at all from my testing.

Also you said to not worry about the bottom two figures, but that 3d model being off center was killing me, so centered it quick.

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
