### PR TITLE
Touchups

### DIFF
--- a/src/components/SNTLmap.vue
+++ b/src/components/SNTLmap.vue
@@ -1595,6 +1595,7 @@ export default {
 <style lang="scss" scoped>
 .map-grid{
   overflow: hidden;
+  margin-top: 25px;
 }
 .grid-left, .grid-right {
   max-height: 70vh;

--- a/src/components/SectionTitle.vue
+++ b/src/components/SectionTitle.vue
@@ -108,9 +108,10 @@ export default {
 .chapterTitle{
     position: relative;
     z-index: 2;
-    font-size: 2em;
+    font-size:clamp(2em, 5vw, 5em);
     color: #fff;
     padding: 0 20px;
     text-align: center;
+    max-width: 960px;
 }
 </style>

--- a/src/components/VizSection.vue
+++ b/src/components/VizSection.vue
@@ -46,7 +46,7 @@ $border: 10px solid #000;
 /*#####TAKE AWAY#####*/
 .takeAway{
     font-size: 1.4em;
-    margin: 0 auto $spacing auto;
+    margin: 0 auto 20px auto;
     max-width: 960px;
     margin: 0 auto;
 }

--- a/src/components/VizSection.vue
+++ b/src/components/VizSection.vue
@@ -45,11 +45,10 @@ $border: 10px solid #000;
 }
 /*#####TAKE AWAY#####*/
 .takeAway{
-    h1{
-        text-align: center;
-        max-width: 80vw;
-    }
-    margin-bottom: $spacing;
+    font-size: 1.4em;
+    margin: 0 auto $spacing auto;
+    max-width: 960px;
+    margin: 0 auto;
 }
 /*#####FIGURES#####*/
 .figures{
@@ -66,14 +65,31 @@ $border: 10px solid #000;
     }
 }
 /*#####FIGURE CAPTION#####*/
-
+.figureCaption{
+  display: flex;
+  justify-content: center;
+  font-size: 1em;
+  line-height: 1.5em; 
+  font-style: italic;
+}
 /*#####EXPLANATION#####*/
+.explanation{
+  font-size: 1.125em;
+  line-height: 1.75em;
+}
 /*#####SHARED CSS#####*/
+.takeAway,
+.figureCaption,
+.explanation{
+  padding: 0 10px;
+}
+
 .figureCaption,
 .explanation{
   max-width: 700px;
-  margin: 0 auto 15px auto;
+  margin: 0 auto $spacing auto;
 }
+
 /*#####CUSTOMIZATION CLASSES#####*/
 .maxWidth{
     max-width: 1500px;
@@ -82,10 +98,6 @@ $border: 10px solid #000;
       max-width: 700px;
       margin: 0 auto;
     }
-}
-.text-content{
-  max-width: 700px;
-  margin: 0 auto;
 }
 .single{
     text-align: center;
@@ -103,6 +115,9 @@ $border: 10px solid #000;
   justify-items: center; 
 }
 @media screen and (min-width: 1024px){
+  .takeAway{
+    font-size: 1.7em
+  }
   /*#####CUSTOMIZATION CLASSES#####*/
     .group{
         display: grid;


### PR DESCRIPTION
Changes made:
-----------
Description

Figure caption and explanation text font sizes and line heights consistent through the app.

Title Sections using clamp to help us keep consistent size through the app.

Fig caption text center no matter how much text there is, BUT keeping left aligned placement to keep it as readable as possible.

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
