### PR TITLE
Safari Splash fix

### DIFF
--- a/src/components/Splash.vue
+++ b/src/components/Splash.vue
@@ -40,7 +40,7 @@
         >
         <img 
           src="@/assets/titleImages/splash/mountainMG-xl.png"
-          xlink:href="@/assets/titleImages/splash/mountainMG-xl.png"
+          href="@/assets/titleImages/splash/mountainMG-xl.png"
           alt="A scene of snowy mountains topped with clouds"
         >
       </picture>
@@ -80,7 +80,7 @@
         >
         <img 
           src="@/assets/titleImages/splash/frozen-lakeFG.png"
-          xlink:href="@/assets/titleImages/splash/frozen-lakeFG.png"
+          href="@/assets/titleImages/splash/frozen-lakeFG.png"
           alt="A frozen lake in front of rocky, snow-covered mountains."
         >
       </picture>
@@ -120,7 +120,7 @@
         >
         <img 
           src="@/assets/titleImages/splash/people-l.png"
-          xlink:href="@/assets/titleImages/splash/people-l.png"
+          href="@/assets/titleImages/splash/people-l.png"
           alt="Clouds rising over the snowy mountain"
         >
       </picture>
@@ -131,8 +131,6 @@
       data-depth="0.80"
     >
       <picture>
-        <!-- Not sure what the browser wants to do with this first one, but it's the largest original -->
-        <source srcset="@/assets/titleImages/splash/cloud.webp">
         <!-- Most compressed -->
         <source
           type="image/webp"
@@ -159,9 +157,9 @@
           srcset="@/assets/titleImages/splash/cloud-l.png"
         >
         <img 
-          src="@/assets/titleImages/splash/cloud.webp"
-          xlink:href="@/assets/titleImages/splash/cloud.webp"
-          alt="Clouds rising over the snowy mountain"
+          src="@/assets/titleImages/splash/cloud-l.png"
+          href="@/assets/titleImages/splash/cloud-l.png"
+          alt="Test"
         >
       </picture>
     </div>
@@ -200,7 +198,7 @@
         >
         <img 
           src="@/assets/titleImages/splash/more-clouds.png"
-          xlink:href="@/assets/titleImages/splash/more-clouds.png"
+          href="@/assets/titleImages/splash/more-clouds.png"
           alt="Clouds rising over the snowy mountain"
         >
       </picture>

--- a/src/components/Splash.vue
+++ b/src/components/Splash.vue
@@ -159,7 +159,7 @@
         <img 
           src="@/assets/titleImages/splash/cloud-l.png"
           href="@/assets/titleImages/splash/cloud-l.png"
-          alt="Test"
+          alt="Clouds rising over the snowy mountain"
         >
       </picture>
     </div>


### PR DESCRIPTION
Changes made:
-----------
Description

Safari was showing a missing image error, sort of.  Wasn't really showing an error but I could tell it was an issue based on its behavior.

It apparently didn't like us having the webp image used as two different source options.  Once I removed one of them it went back to working order.  Let me know if you see something off after this change.  

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
