### PR TITLE
rearrange the story flow

### DIFF
--- a/src/components/DiagramsHigh.vue
+++ b/src/components/DiagramsHigh.vue
@@ -1,0 +1,60 @@
+<template>
+  <!---VizSection-->
+  <VizSection id="diagrams-high">
+    <!-- TAKEAWAY TITLE -->
+    <template v-slot:takeAway>
+      <h2>High Snow + Late Melt = Lots of Flow</h2>
+    </template>
+    <template v-slot:aboveExplanation>
+      <p>In a good snow year, there's lots of snow and it doesn't melt at all until the spring when it melts all at once.</p>
+    </template>
+    <!-- FIGURES -->
+    <template v-slot:figures>
+      <div class="group two maxWidth">
+        <figure id="good-snow">
+          <img 
+            id="diagram-good-winter"
+            v-img:group-good
+            src="@/assets/diagrams/Diagrams_snow-good.png"
+            alt="A diagram of a mountain hillside in a high-snow winter, where there's thick snowpack and saturated soils from good snow years previously."
+            loading="lazy"
+          >
+        </figure>
+        <figure id="good-flow">
+          <img 
+            id="diagram-good-spring"
+            v-img:group-good
+            src="@/assets/diagrams/Diagrams_flow-good.png"
+            alt="A diagram of a mountain hillside in spring after a high-snow winter, where the snowpack melts all at once and makes lots of meltwater available for water supply."
+            loading="lazy"
+          >
+        </figure>
+      </div>
+    </template>
+    <!-- FIGURE CAPTION -->
+    <template v-slot:figureCaption>
+      <p>
+        Typical snow accumulation during winter months forms snowpack, which acts as water storage until warmer temperatures in the spring and summer months lead to snowmeltand ultimately streamflow that flow through the landscape.
+      </p>
+    </template>
+    <!-- EXPLANATION -->
+    <template v-slot:belowExplanation>
+      <p>Goat fondue cheese and wine. Caerphilly feta goat cheese triangles taleggio ricotta queso caerphilly. Jarlsberg say cheese boursin monterey jack cauliflower cheese blue castello roquefort chalk and cheese. Brie dolcelatte bavarian bergkase chalk and cheese cottage cheese port-salut cottage cheese lancashire. Pepper jack swiss.</p>
+    </template>
+  </VizSection>
+</template>
+<script>
+import VizSection from '@/components/VizSection';
+import Fig from '@/components/Figure';
+
+export default {
+    name: "DiagramsHigh",
+    components:{
+        VizSection
+    }
+}
+</script>
+<style lang="scss" scoped>
+
+
+</style>

--- a/src/components/DiagramsLow.vue
+++ b/src/components/DiagramsLow.vue
@@ -1,9 +1,9 @@
 <template>
   <!---VizSection-->
-  <VizSection id="firstSection">
+  <VizSection id="diagrams-low">
     <!-- TAKEAWAY TITLE -->
     <template v-slot:takeAway>
-      <h2>A Bad Snow Year</h2>
+      <h2>Low Snow + Early Melting = Less Flow</h2>
     </template>
     <template v-slot:aboveExplanation>
       <p>But warmer winters mean less snow and earlier melt, which means low spring flows.</p>
@@ -46,7 +46,7 @@
 <script>
 import VizSection from '@/components/VizSection';
 export default {
-    name: "DiagramsBad",
+    name: "DiagramsLow",
     components:{
         VizSection
     }

--- a/src/components/DiagramsNormal.vue
+++ b/src/components/DiagramsNormal.vue
@@ -1,12 +1,12 @@
 <template>
   <!---VizSection-->
-  <VizSection id="firstSection">
+  <VizSection id="diagrams-normal">
     <!-- TAKEAWAY TITLE -->
     <template v-slot:takeAway>
-      <h2>A Good Snow Year</h2>
+      <h2>How much snow (magnitude) and how late into the year it sticks around (timing) matter for making meltwater available for water use.</h2>
     </template>
     <template v-slot:aboveExplanation>
-      <p>In a good snow year, there's lots of snow and it doesn't melt at all until the spring when it melts all at once.</p>
+      <p>How snow turns into flow is dependent on a few dynamics.  Explain the forcings in plain language: it matters how much snow there is, how long into the spring it lasts, and whether it melts bit by bit or all at once</p>
     </template>
     <!-- FIGURES -->
     <template v-slot:figures>
@@ -48,7 +48,7 @@ import VizSection from '@/components/VizSection';
 import Fig from '@/components/Figure';
 
 export default {
-    name: "DiagramsGood",
+    name: "DiagramsNor al",
     components:{
         VizSection
     }

--- a/src/components/Impact.vue
+++ b/src/components/Impact.vue
@@ -1,15 +1,16 @@
 <template>
   <!---VizSection-->
-  <VizSection id="firstSection">
+  <VizSection id="impact">
     <!-- TAKEAWAY TITLE -->
     <template v-slot:takeAway>
-      <h2>There are enormous impacts of a changing snow pattern.</h2>
+      <h2>Changing snow in the west can have enormous impacts on water availability.</h2>
     </template>
     <!-- FIGURES -->
     <template v-slot:aboveExplanation>
-      <p>Here's all about it. One final diagram to hit home the fact that snowpack is measurably changing  in the places where it matters.</p>
+      <p>Reiterate why this matters.</p>
+      <p>The USGS is doing lots of research to track changing snow patterns across the country.</p> 
     </template>
-    <template v-slot:figures>
+    <!-- <template v-slot:figures>
       <div class="single maxWidth">
         <figure id="swe-chart-container">
           <img 
@@ -37,19 +38,15 @@
           >
         </figure>
       </div>
-    </template>
+    </template> -->
     <!-- FIGURE CAPTION -->
-    <template v-slot:figureCaption>
+    <!-- <template v-slot:figureCaption>
       <p>
         Cottage cheese mascarpone cut the cheese. Cheeseburger cauliflower cheese babybel cheese slices camembert de normandie stinking bishop chalk and cheese cottage cheese. Who moved my cheese edam chalk and cheese croque monsieur hard cheese macaroni cheese monterey jack cheddar.
       </p>
-    </template>
+    </template> -->
     <!-- EXPLANATION -->
     <template v-slot:belowExplanation>
-      <p>Reiterate what we said at the very beginning.  April 1st used to mark peak snowpack. But that's changing because of climate change.  And it has lots of impacts on water supply.</p>
-      <p>Specifically, a smaller snowpack that melts earlier will mean less water available for supply.  It also means drier soils, and potentially more wildfires. List all the impacts and cite sources that support these claims.</p>
-      <p>Halloumi boursin cut the cheese. Who moved my cheese dolcelatte cheesecake squirty cheese babybel fromage everyone loves goat. Airedale cream cheese edam parmesan port-salut manchego stinking bishop stilton. Cut the cheese hard cheese pepper jack swiss brie paneer the big cheese cow. Fondue.</p>
-      <h2>Follow the Story</h2>
       <p>Check back in with the snow hydrology group and usgs vizlab this summer when we look back at what the water availability driven by today's snowpack looks like over the spring and summer.</p>
     </template>
   </VizSection>

--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -1,0 +1,57 @@
+<template>
+  <!---VizSection-->
+  <VizSection id="intro">
+    <!-- TAKEAWAY TITLE -->
+    <template v-slot:takeAway>
+      <h2>Almost 70% of water in the west comes from snowmelt.</h2>
+    </template>
+    <template v-slot:aboveExplanation>
+      <p>So with warmer, shorter winters, what does that mean for water availability?</p>
+      <p>Taleggio cheese strings manchego. Cheese strings queso when the cheese comes out everybody's happy pecorino say cheese when the cheese comes out everybody's happy blue castello boursin. Brie blue castello cauliflower cheese paneer goat edam cut the cheese bavarian bergkase. Roquefort mozzarella squirty cheese airedale cauliflower cheese cream cheese goat goat. Lancashire cheese slices smelly cheese smelly cheese.</p>
+    </template>
+    <!-- FIGURES -->
+    <!-- <template v-slot:figures>
+      <div class="group two maxWidth diagram">
+        <figure id="bad-snow">
+          <img 
+            id="diagram-bad-winter"
+            v-img:group-bad
+            src="@/assets/diagrams/Diagrams_snow-bad.png"
+            alt="A diagram of a mountain hillside in a low-snow winter, where there's not much snowpack and warm weather is melting the snow intermittently."
+            loading="lazy"
+          >
+        </figure>
+        <figure id="bad-flow">
+          <img 
+            id="diagram-bad-spring"
+            v-img:group-design
+            src="@/assets/diagrams/Diagrams_flow-bad.png"
+            alt="A diagram of a mountain hillside in spring after a low-snow winter, where there is little snow left and little water in streams."
+            loading="lazy"
+          >
+        </figure>
+      </div>
+    </template> -->
+    <!-- FIGURE CAPTION -->
+    <!-- <template v-slot:figureCaption>
+      <p>
+        With global changes in precipitation and temperature, snowmelt and sublimintation can occur at accelerated rates leading to lower levels of streamflow.
+      </p>
+    </template> -->
+    <!-- EXPLANATION -->
+    <template v-slot:belowExplanation>
+      <p>Parmesan cheeseburger emmental. Monterey jack dolcelatte stinking bishop paneer croque monsieur manchego airedale squirty cheese. The big cheese mozzarella red leicester port-salut the big cheese cheeseburger queso cheesy grin. Boursin babybel.</p>
+    </template>
+  </VizSection>
+</template>
+<script>
+import VizSection from '@/components/VizSection';
+export default {
+    name: "Intro",
+    components:{
+        VizSection
+    }
+}
+</script>
+<style lang="scss" scoped>
+</style>

--- a/src/components/MeasuringSWE.vue
+++ b/src/components/MeasuringSWE.vue
@@ -1,9 +1,9 @@
 <template>
   <!---VizSection-->
-  <VizSection id="firstSection">
+  <VizSection id="measuring-swe">
     <!-- TAKEAWAY TITLE -->
     <template v-slot:takeAway>
-      <h2>How the USGS Measures Snowpack</h2>
+      <h2>The USGS has been studying the connection between snowpack and stream flow for decades.</h2>
     </template>
     <template v-slot:aboveExplanation>
       <p>Cheese and wine roquefort when the cheese comes out everybody's happy. Cow red leicester the big cheese paneer cut the cheese red leicester boursin halloumi. Cheese and wine cheddar mozzarella boursin mozzarella cheese and wine taleggio cheese slices. Stilton fromage say cheese mozzarella cheeseburger dolcelatte pepper jack manchego. Who moved my cheese feta.</p>

--- a/src/components/SNTLmap.vue
+++ b/src/components/SNTLmap.vue
@@ -5,7 +5,7 @@
   >
     <!-- TAKEAWAY TITLE -->
     <template v-slot:takeAway>
-      <h2>Today is an important day in the world of snow hydrology.</h2>
+      <h2>Snowmelt season has already begun.</h2>
     </template>    
     <!-- EXPLANATION -->
     <template v-slot:aboveExplanation>
@@ -1448,7 +1448,7 @@
     </template>
     <!-- EXPLANATION -->
     <template v-slot:belowExplanation>
-      <p>Transition from the significance of April 1st to explain...well, how do we actually measure that?</p>
+      <p>Find what snowpack has looked like this year in SNOTEL monitoring locations across the country.</p>
       <p>Cheeseburger cut the cheese taleggio. Emmental croque monsieur mascarpone red leicester blue castello airedale everyone loves st. agur blue cheese. Cottage cheese cheese strings ricotta babybel cheeseburger queso manchego fromage. Paneer pepper jack cheese slices halloumi cream cheese jarlsberg chalk and cheese everyone loves. Smelly cheese stinking bishop cheesy grin pepper jack.</p>
     </template>
   </VizSection>

--- a/src/components/SWE.vue
+++ b/src/components/SWE.vue
@@ -1,9 +1,9 @@
 <template>
   <!---VizSection-->
-  <VizSection id="firstSection">
+  <VizSection id="swe-line-chart">
     <!-- TAKEAWAY TITLE -->
     <template v-slot:takeAway>
-      <h2>Snowpack hints at the upcoming meltwater availability.</h2>
+      <h2>Each year, scientists find relationships between a snowpack curve and discharge at a streamgage downstream.</h2>
     </template>
     <!-- FIGURES -->
     <template v-slot:aboveExplanation>

--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -1,7 +1,31 @@
 <template>
   <div id="visualization">
     <Splash />
-    <SNTLMap v-if="checkIfSplashIsRendered" />
+    <Intro />
+    <Chapter
+      v-if="checkIfSplashIsRendered"
+      id="chapter2"
+      image="chapter5"
+      alt="An image of a greenish-blue river winding through a snowy forest, faded into the background to serve as a backdrop for the section title."
+      :height="50"
+    >
+      <template v-slot:chapterTitle>
+        From Winter Snow to Spring Flow
+      </template>
+    </Chapter>
+    <DiagramsNormal 
+      v-if="checkIfSplashIsRendered"
+      id="diagrams-normal"
+    />
+    <DiagramsHigh 
+      v-if="checkIfSplashIsRendered"
+      id="diagrams-good"
+    />
+    <DiagramsLow 
+      v-if="checkIfSplashIsRendered"
+      id="diagrams-bad"
+    />
+    
     <Chapter
       v-if="checkIfSplashIsRendered"
       id="chapter1"
@@ -17,25 +41,6 @@
     <SWE v-if="checkIfSplashIsRendered" />
     <Chapter
       v-if="checkIfSplashIsRendered"
-      id="chapter2"
-      image="chapter5"
-      alt="An image of a greenish-blue river winding through a snowy forest, faded into the background to serve as a backdrop for the section title."
-      :height="50"
-    >
-      <template v-slot:chapterTitle>
-        From Winter Snow to Spring Flow
-      </template>
-    </Chapter>
-    <DiagramsGood 
-      v-if="checkIfSplashIsRendered"
-      id="diagrams-good"
-    />
-    <DiagramsBad 
-      v-if="checkIfSplashIsRendered"
-      id="diagrams-bad"
-    />
-    <Chapter
-      v-if="checkIfSplashIsRendered"
       id="chapter2-3"
       image="chapter9"
       alt="An landscape of snowy mountain tops with pine trees in the valley and a bright blue sky overhead, faded into the background to serve as a backdrop for the section title."
@@ -45,6 +50,7 @@
         Changes in snow have downstream consequences
       </template>    
     </Chapter>
+    <SNTLMap v-if="checkIfSplashIsRendered" />
     <SWEanim v-if="checkIfSplashIsRendered" />
     <Chapter
       v-if="checkIfSplashIsRendered"
@@ -80,13 +86,15 @@ export default {
     name: 'Visualization',
     components: {
       Splash: () => import( /* webpackPrefetch: true */ /*webpackChunkName: "section"*/ "./../components/Splash"),
+      Intro: () => import( /*webpackChunkName: "Intro"*/ "./../components/Intro"),
       SNTLMap: () => import( /*webpackChunkName: "SNTLMap"*/ "./../components/SNTLmap"),
       SWE: () => import( /*webpackChunkName: "SWE"*/ "./../components/SWE"),
       SWEanim: () => import( /*webpackChunkName: "SWE"*/ "./../components/SWEanim"),
       MeasuringSWE: () => import( /*webpackChunkName: "SWE"*/ "./../components/MeasuringSWE"),
       // SWEtoDischarge: () => import( /*webpackChunkName: "SWE"*/ "./../components/SWEtoDischarge"),
-      DiagramsGood: () => import( /*webpackChunkName: "diagramsgood"*/ "./../components/DiagramsGood"),
-      DiagramsBad: () => import( /*webpackChunkName: "diagramsbad"*/ "./../components/DiagramsBad"),
+      DiagramsNormal: () => import( /*webpackChunkName: "diagramsnormal"*/ "./../components/DiagramsNormal"),
+      DiagramsHigh: () => import( /*webpackChunkName: "diagramshigh"*/ "./../components/DiagramsHigh"),
+      DiagramsLow: () => import( /*webpackChunkName: "diagramslow"*/ "./../components/DiagramsLow"),
       Impact: () => import( /*webpackChunkName: "impact"*/ "./../components/Impact"),
       References: () => import( /*webpackChunkName: "References"*/ "./../components/References"),
       Chapter: () => import( /*webpackChunkName: "ChapterTitles"*/ "./../components/SectionTitle"),


### PR DESCRIPTION
Changes made: Renamed and rearranged components to fit the story flow that CN and EB decided on after the Vizlab Crit and CDI webinar
-----------
Description


Testing:
----------------------------
Before making this pull request, I:
- [x] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
