### PR TITLE
Bugs

### DIFF
--- a/src/components/Impact.vue
+++ b/src/components/Impact.vue
@@ -1,6 +1,10 @@
 <template>
   <!---VizSection-->
-  <VizSection id="impact">
+  <VizSection
+    id="impact"
+    :figures="false"
+    :fig-caption="false"
+  >
     <!-- TAKEAWAY TITLE -->
     <template v-slot:takeAway>
       <h2>Changing snow in the west can have enormous impacts on water availability.</h2>
@@ -10,41 +14,6 @@
       <p>Reiterate why this matters.</p>
       <p>The USGS is doing lots of research to track changing snow patterns across the country.</p> 
     </template>
-    <!-- <template v-slot:figures>
-      <div class="single maxWidth">
-        <figure id="swe-chart-container">
-          <img 
-            v-img:final
-            src="@/assets/images/rio_peak.png"
-            alt="A placeholder diagram"
-            loading="lazy"
-          >
-        </figure>
-        <figure id="swe-chart-container">
-          <img 
-            v-img:final
-            src="@/assets/images/rio_sm50.png"
-            alt="A placeholder diagram"
-            loading="lazy"
-          >
-        </figure>
-
-        <figure id="change">
-          <img 
-            v-img:final
-            src="@/assets/images/rio_change.png"
-            alt="A placeholder diagram"
-            loading="lazy"
-          >
-        </figure>
-      </div>
-    </template> -->
-    <!-- FIGURE CAPTION -->
-    <!-- <template v-slot:figureCaption>
-      <p>
-        Cottage cheese mascarpone cut the cheese. Cheeseburger cauliflower cheese babybel cheese slices camembert de normandie stinking bishop chalk and cheese cottage cheese. Who moved my cheese edam chalk and cheese croque monsieur hard cheese macaroni cheese monterey jack cheddar.
-      </p>
-    </template> -->
     <!-- EXPLANATION -->
     <template v-slot:belowExplanation>
       <p>Check back in with the snow hydrology group and usgs vizlab this summer when we look back at what the water availability driven by today's snowpack looks like over the spring and summer.</p>

--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -1,6 +1,10 @@
 <template>
   <!---VizSection-->
-  <VizSection id="intro">
+  <VizSection
+    id="intro"
+    :figures="false"
+    :fig-caption="false"
+  >
     <!-- TAKEAWAY TITLE -->
     <template v-slot:takeAway>
       <h2>Almost 70% of water in the west comes from snowmelt.</h2>
@@ -9,35 +13,6 @@
       <p>So with warmer, shorter winters, what does that mean for water availability?</p>
       <p>Taleggio cheese strings manchego. Cheese strings queso when the cheese comes out everybody's happy pecorino say cheese when the cheese comes out everybody's happy blue castello boursin. Brie blue castello cauliflower cheese paneer goat edam cut the cheese bavarian bergkase. Roquefort mozzarella squirty cheese airedale cauliflower cheese cream cheese goat goat. Lancashire cheese slices smelly cheese smelly cheese.</p>
     </template>
-    <!-- FIGURES -->
-    <!-- <template v-slot:figures>
-      <div class="group two maxWidth diagram">
-        <figure id="bad-snow">
-          <img 
-            id="diagram-bad-winter"
-            v-img:group-bad
-            src="@/assets/diagrams/Diagrams_snow-bad.png"
-            alt="A diagram of a mountain hillside in a low-snow winter, where there's not much snowpack and warm weather is melting the snow intermittently."
-            loading="lazy"
-          >
-        </figure>
-        <figure id="bad-flow">
-          <img 
-            id="diagram-bad-spring"
-            v-img:group-design
-            src="@/assets/diagrams/Diagrams_flow-bad.png"
-            alt="A diagram of a mountain hillside in spring after a low-snow winter, where there is little snow left and little water in streams."
-            loading="lazy"
-          >
-        </figure>
-      </div>
-    </template> -->
-    <!-- FIGURE CAPTION -->
-    <!-- <template v-slot:figureCaption>
-      <p>
-        With global changes in precipitation and temperature, snowmelt and sublimintation can occur at accelerated rates leading to lower levels of streamflow.
-      </p>
-    </template> -->
     <!-- EXPLANATION -->
     <template v-slot:belowExplanation>
       <p>Parmesan cheeseburger emmental. Monterey jack dolcelatte stinking bishop paneer croque monsieur manchego airedale squirty cheese. The big cheese mozzarella red leicester port-salut the big cheese cheeseburger queso cheesy grin. Boursin babybel.</p>

--- a/src/components/SectionTitle.vue
+++ b/src/components/SectionTitle.vue
@@ -92,7 +92,7 @@ picture{
   transition: filter 0.5s;
 }
 .lazy{
-  filter: blur(20px);
+  filter: blur(50px);
 }
 .overlay{
     position: absolute;

--- a/src/components/SectionTitle.vue
+++ b/src/components/SectionTitle.vue
@@ -82,13 +82,17 @@ export default {
     overflow: hidden;
 }
 /* force the source element to be full height*/
-picture{
-  source{
+picture, source{
     position: absolute;
     top: 0;
     width: 100%;
     height: 100%;
-  }
+}
+picture{
+  transition: filter 0.5s;
+}
+.lazy{
+  filter: blur(20px);
 }
 .overlay{
     position: absolute;

--- a/src/components/VizSection.vue
+++ b/src/components/VizSection.vue
@@ -9,12 +9,18 @@
       <div class="aboveExplanation explanation">
         <slot name="aboveExplanation" />
       </div>
-      <div class="figures">
+      <div
+        v-if="figures"
+        class="figures"
+      >
         <slot name="figures">
           Figure(s)
         </slot>
       </div>
-      <div class="figureCaption">
+      <div
+        v-if="figCaption"
+        class="figureCaption"
+      >
         <slot name="figureCaption">
           Figure Caption
         </slot>
@@ -27,7 +33,17 @@
 </template>
 <script>
 export default {
-    name: "VizSection"
+    name: "VizSection",
+    props:{
+        figCaption:{
+          type: Boolean,
+          default: true
+        },
+        figures:{
+          type: Boolean,
+          default: true
+        }
+    }
 }
 </script>
 <style scoped lang="scss">
@@ -71,6 +87,9 @@ $border: 10px solid #000;
 .explanation{
   font-size: 1.125em;
   line-height: 1.75em;
+  p{
+    padding: 0 0 10px 0;
+  }
 }
 /*#####SHARED CSS#####*/
 .takeAway,

--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -1,7 +1,9 @@
 <template>
   <div id="visualization">
     <Splash />
-    <Intro />
+    <Intro
+      v-if="checkIfSplashIsRendered"
+    />
     <Chapter
       v-if="checkIfSplashIsRendered"
       id="chapter2"
@@ -112,7 +114,7 @@ export default {
         this.parallaxScroll();
       })
     },
-    beforeUpdate(){
+    updated(){
       this.lazyLoadImages();
     },
     methods:{
@@ -133,25 +135,29 @@ export default {
       },
       lazyLoadImages(){
         const loadImg = function(entries, observer){
-          const [entry] = entries;
-          //Guard Clause
-          //If image is not intersecting viewport do nothing
-          if (!entry.isIntersecting) return;
-          //Get first source element
-          entry.target.srcset = entry.target.dataset.srcset; 
-          //Get second source element
-          entry.target.nextElementSibling.srcset = entry.target.dataset.srcset; 
-          //stop observing img after the switch
-          observer.unobserve(entry.target);
+          entries.forEach(entry => {
+            if(entry.isIntersecting){
+              console.log(entry);
+              //Get first source element
+              entry.target.srcset = entry.target.dataset.srcset; 
+              //Get second source element
+              entry.target.nextElementSibling.srcset = entry.target.dataset.srcset; 
+              entry.target.parentElement.classList.remove('lazy');
+              observer.unobserve(entry.target);
+              observer.unobserve(entry.target.nextElementSibling);
+            }
+          });
         }
         const imgTargets = document.querySelectorAll(".lazy > source");
-        const imgObserver = new IntersectionObserver(loadImg, {
+        const imgObserver = new window.IntersectionObserver(loadImg, {
           //Watch entire viewport
           root: null,
           threshold: 0,
           rootMargin: "300px"
         })
-        imgTargets.forEach(img => imgObserver.observe(img));
+        imgTargets.forEach(img => {
+          imgObserver.observe(img)
+        });
       }
     }
 } 

--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -137,14 +137,15 @@ export default {
         const loadImg = function(entries, observer){
           entries.forEach(entry => {
             if(entry.isIntersecting){
-              console.log(entry);
               //Get first source element
               entry.target.srcset = entry.target.dataset.srcset; 
               //Get second source element
               entry.target.nextElementSibling.srcset = entry.target.dataset.srcset; 
-              entry.target.parentElement.classList.remove('lazy');
+              const findImg = entry.target.parentElement.querySelector("img");
+              findImg.addEventListener('load', function () {
+                entry.target.parentElement.classList.remove('lazy');
+              });
               observer.unobserve(entry.target);
-              observer.unobserve(entry.target.nextElementSibling);
             }
           });
         }


### PR DESCRIPTION
Changes made:
-----------
Description

Images now load correctly when loaded on screen.

Added control props to the viz section component, so when you don't want figures or a fig caption you can just add the props and forgo the html templates associated with them.

Added these to the intro and impact components

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
