### PR TITLE
Large screen fix for splash

### DIFF
--- a/src/components/Splash.vue
+++ b/src/components/Splash.vue
@@ -222,7 +222,7 @@ export default {
             this.$gsap.registerPlugin(ScrollToPlugin, ScrollTrigger); // register gsap plugins for scrollTrigger 
                 ScrollTrigger.matchMedia({
                     //desktop 
-                    "(min-width: 800px)": function(){
+                    "(min-width: 800px) and (max-width: 2619px)": function(){
                         self.$gsap.timeline({
                             scrollTrigger:{
                                 trigger: ".splash",
@@ -236,6 +236,21 @@ export default {
                         .fromTo("#people", {yPercent: 17}, {yPercent: -11}, 0)
                         .fromTo("#water", {yPercent: 15}, {yPercent: -10}, 0)
                         .fromTo("#mountains", {yPercent: 10}, {yPercent: -2}, 0)
+                    },
+                    "(min-width: 2620px)": function(){
+                        self.$gsap.timeline({
+                            scrollTrigger:{
+                                trigger: ".splash",
+                                start: "top top",
+                                end:`bottom center`,
+                                scrub: true
+                            }
+                        })
+                        .fromTo("#more-clouds", {yPercent: 2}, {yPercent: -40}, 0)
+                        .fromTo("#clouds", {yPercent: 20}, {yPercent: -10}, 0)
+                        .fromTo("#people", {yPercent: 17}, {yPercent: -11}, 0)
+                        .fromTo("#water", {yPercent: 15}, {yPercent: -10}, 0)
+                        .fromTo("#mountains", {yPercent: 0}, {yPercent: 0}, 0)
                     }
                 })
         }
@@ -282,7 +297,7 @@ export default {
     height: 100%;
 }
 .element img{
-    object-fit: contain;
+    object-fit: cover;
     object-position: center;
     width: 100%;
     height: 100%;
@@ -299,18 +314,9 @@ export default {
 #clouds{
     z-index: 25;
     height: 125%;
-    // display: none;
 }
 #more-clouds {
-   z-index: 30;
+  z-index: 30;
   height: 125%;
-}
-.cover {
-  object-fit: cover;
-}
-@media screen and (min-width:800px){
-    #clouds{
-        display: block;
-    }
 }
 </style>


### PR DESCRIPTION
Changes made:
-----------
Description

object-fit contain was stopping out splash images from being full screen on larger screens.  Object-fit cover to the rescue!  Also I stopped the mountains from moving on the larger screens as it was buggy, but we still get that parallax effect we desire.

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
