### PR TITLE
set up ridge transitions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -63,8 +63,8 @@
 
  // IMPORT
 $nearBlack: #1a1b1c; //#1a1b1c;
-$frostyGreen: #76A28E; // good contrast against black (original was #5e8a76)
-$deepGreen: #2A4C40; // good contrast against white
+$frostyGreen: #90d3b5; // good contrast against black (original was #5e8a76)
+$deepGreen: #235845; // good contrast against white
 $frostyPurple: #C9ADE6;
 $deepPurple: #301546; // good contrast against black
 $skyBlue: #7AC3FF;
@@ -107,7 +107,7 @@ h2{
   font-weight: 600;
   text-align: left;
   font-family:$familyMain;
-  font-size: 1.5em;
+  font-size: 1.3em;
   margin-top: 5px;
   line-height: 1.2;
   @media screen and (max-width: 600px) {

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -12,14 +12,6 @@
         This was because of differences in the amount of snowpack between years - in 2011 peak SWE was  2x higher.  there were considerable difference in the magnitude of SWE and subsequently discharge at the shown locations in the Upper Colorado river basin.
         With 2 times higher snowpack shown int he line chart. 
       </p>
-      <div class="compare">
-        <h4>Compare: <input type="radio" id="one" value="One" v-model="picked">
-          <label for="one">timing</label>   
-        <input type="radio" id="two" value="Two" v-model="picked">
-          <label for="two">magnitude</label>
-        <input type="radio" id="two" value="Two" v-model="picked">   
-          <label for="three">elevation</label></h4>
-        </div>
     </template>
     <!-- FIGURES -->
     <template v-slot:figures>
@@ -82,21 +74,32 @@
             id="mmd-line-both"
             xmlns="http://www.w3.org/2000/svg"
             xmlns:xlink="http://www.w3.org/1999/xlink"
-            viewBox="-50 -50 600 500"
+            viewBox="-50 -50 600 550"
             aria-labelledby="page-title page-desc"
             width="100%"
           >
 
             <text
-              x="100"
-              y="0"
-            >High snow</text>
+              x="90"
+              y="470"
+            >High snow year</text>
             <text
-              x="400"
-              y="0"
-            >Low snow</text>
+              x="350"
+              y="470"
+            >Low snow year</text>
           </svg>
         </div>
+        <div class="compare">
+        <div class="btn-group" data-toggle="buttons">
+                  <h4 class="butt-head" >Compare streamflow: 
+  <input class="butt" id="rb1" type="radio" name="radiogroup1" checked=true >
+    <label class="butt" for="rb1">timing</label>
+    <input  class="butt" id="rb2" type="radio" name="radiogroup1">
+    <label class="butt" for="rb2">magnitude</label>
+    <input class="butt" id="rb3" type="radio" name="radiogroup1">
+    <label class="butt" for="rb3">by elevation</label></h4>
+</div>
+      </div>
       </div>
     </template>
     <!-- FIGURE CAPTION -->
@@ -122,6 +125,7 @@ export default {
     },
     data() {
             return {
+              isActive: false,
               title: process.env.VUE_APP_TITLE,
               publicPath: process.env.BASE_URL,
               d3: null,
@@ -477,6 +481,9 @@ export default {
  
     }
     },
+    toggle() {
+   this.isActive = !this.isActive;
+  },
 }
 </script>
 <style lang="scss" scoped>
@@ -487,11 +494,40 @@ export default {
 
 }
 .maxWidth {
-  max-width: 50vw;
+  width: 90vw;
+  max-width: 700px;
+  margin: auto;
 }
 input {
   margin-left: 20px;
   margin-right: 5px;
   display: inline-block;
 }
+.compare {
+  border: 2px solid black;
+  display: inline-block;
+  font-size: 18px;
+  text-align: center;
+    padding: 5px 10px;
+}
+
+.butt {
+  padding: 5px 10px;
+}
+input[name="radiogroup1"] {
+            display: none;
+        }
+         input[name="radiogroup1"]+label {
+            /* style passive state as you like */
+            border: 2px solid transparent;
+            color: black;
+            font-weight: 400;
+        }
+
+    input[name="radiogroup1"]:checked+label {
+        /* style checked state as you like */
+        border: 7px solid orchid;
+        background-color: orchid;
+        color: white;
+    }
 </style>

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -369,14 +369,15 @@ export default {
         .transition()
         .duration(700)
         .delay(250)
-        .call(self.yAxis);
+        .call(self.yAxis)
+        .attr("transform", "translate(0, -205)");
 
         this.d3.select(".yaxis.ridge_2011")
         .transition()
         .duration(500)
         .delay(450)
         .call(self.yAxis)
-        .attr("transform", "translate(0, -207)");
+        .attr("transform", "translate(0, 0)");
         
 
         this.d3.selectAll("g.ridge_2011.curve")
@@ -409,6 +410,12 @@ export default {
           return "translate(0," + (0) + ") scale(1, 1)"
         })
 
+        this.d3.selectAll("g.yaxis g")
+        .transition()
+        .duration(500)
+        .delay(300)
+        .attr("opacity", 1)
+
 
 
       },
@@ -434,7 +441,19 @@ export default {
           return "translate(0," + (0) + ") scale(1, 1)"
         })
 
+        this.d3.selectAll("g.yaxis g")
+        .transition()
+        .duration(500)
+        .delay(300)
+        .attr("opacity", 1)
+
         
+        this.d3.select(".yaxis.ridge_2011")
+        .transition()
+        .duration(500)
+        .delay(450)
+        .call(self.yAxis)
+        .attr("transform", "translate(0, -2)");
 
         
       },
@@ -476,6 +495,12 @@ export default {
         .duration(500)
         .delay(350)
         .call(yAxisTall);
+
+        this.d3.selectAll("g.yaxis g")
+        .transition()
+        .duration(500)
+        .delay(300)
+        .attr("opacity", 0)
 
 
       },

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -74,20 +74,20 @@
             id="mmd-line-both"
             xmlns="http://www.w3.org/2000/svg"
             xmlns:xlink="http://www.w3.org/1999/xlink"
-            viewBox="0 -50 550 520"
+            viewBox="-50 -50 600 500"
             aria-labelledby="page-title page-desc"
             width="100%"
             height="auto"
           >
 
-            <text class="yr-label"
-              x="150"
-              y="450"
-            >High snow year</text>
-            <text class="yr-label"
-              x="400"
-              y="450"
-            >Low snow year</text>
+            <text class="yr-label" id="wy11"
+              x="50"
+              y="175"
+            >High snow</text>
+            <text class="yr-label" id="wy12"
+              x="50"
+              y="375"
+            >Low snow</text>
           </svg>
         </div>
         <div class="compare">
@@ -147,6 +147,8 @@ export default {
               site_elev: [],
               site_sp: [],
               tickDates: ["Oct", "Jan", "Apr", "July"],
+              highlabel: null,
+              lowlabel: null,
         
 
               checkedData: ["mmd"],
@@ -224,8 +226,8 @@ export default {
         var mar = mid*0.05
 
         // set chart - separate for each year, using 2011 for max values to set the scaless
-        self.initRidges(this.svgboth, 'ridge_2011', data.mmd11, data.days, 0, x_long, this.margin, this.height/2-mar);
-        self.initRidges(this.svgboth, 'ridge_2012', data.mmd12, data.days, 0, x_long, this.height/2+mar,  this.height);
+        self.initRidges(this.svgboth, 'ridge_2011', data.mmd11, data.days, 0, x_long, this.margin, this.height/2);
+        self.initRidges(this.svgboth, 'ridge_2012', data.mmd12, data.days, 0, x_long, this.height/2+mar+2,  this.height+2);
 
 
 
@@ -260,9 +262,9 @@ export default {
 
         // define & style x &  y axes
         var xAxis = g => g
-          .attr("transform", `translate(0,${this.height})`)
+          .attr("transform", `translate(0,${this.height+2})`)
           .call(this.d3.axisBottom(x)
-              .tickValues([50, 143, 223, 313])
+              .tickValues([1, 93, 183, 273])
               .tickFormat(function(d,i) { return self.tickDates[i] })
               .tickSizeOuter(0).tickSize(0))
 
@@ -283,15 +285,6 @@ export default {
           
         this.line = this.area.lineY1()
           .defined(d => !isNaN(d));
-        
-        var colorStack = this.d3.scaleOrdinal()
-        .domain(["site_6614800", "site_9063900","site_9034900","site_9035500","site_6746095",
-            "site_9064000","site_9065500","site_9066200","site_9022000","site_9032100","site_9065100","site_7083000","site_9035700","site_9046490","site_9035900", 
-            "site_9024000","site_9358550","site_9025000","site_9066000","site_9074000","site_9026500","site_9032000","site_9051050","site_9025300","site_9067200",
-            "site_9066300","site_9047700","site_9067000","site_9132995","site_9134000","site_9306242"])
-        .range(["blue", "blue", "blue", "blue", "blue", "dodgerblue", "dodgerblue", "dodgerblue", "dodgerblue", "dodgerblue", 
-                "green","green","green","green","green","lightgreen","lightgreen","lightgreen","lightgreen","lightgreen",
-                "gold","gold","gold","gold","gold","yellow","yellow","yellow","yellow","yellow"])
 
       // append g for each ridgeline/site_no
         this.group = svg.append("g")
@@ -312,26 +305,47 @@ export default {
           .attr("stroke", "dodgerblue")
           .attr("d", d => this.line(d.mmd))
           .attr("stroke-width", "1px")
-          .attr("stroke", function(d) { return colorStack(d.key)})
+          .attr("stroke", "dodgerblue")
+          .attr("opacity", 0.7)
           .attr("class", function(d) { return d.key })
           .classed("ridge", true);
 
           
         this.y2011 = this.svgboth.selectAll("g.ridge_2011")
         this.y2012 = this.svgboth.selectAll("g.ridge_2012")
+        this.highlabel = this.svgboth.select("#wy11")
+        this.lowlabel = this.svgboth.select("#wy12")
 
-          self.stackRidges();
-          self.shiftRidges(svg, days);
-          self.spreadRidges();
+      self.timingToMagnitude(svg, days);
+
+          //self.spreadRidges(); 
 
       },
+      timingToMagnitude(svg, days){
+        const self = this;
+        self.stackRidges();
+      self.shiftRidges(svg, days);
+      },
       stackRidges(){
+        const self = this;
 
         this.y2011.selectAll("path.ridge")
           .transition()
-          .delay(function(d,i) { return i*20 })
-          .duration(500)
-          .attr("transform", "translate(0," + (this.height/2+(this.height/2)*0.05) + ")" )
+          .delay(function(d,i) { return i*15 })
+          .duration(1100)
+          .attr("transform", "translate(0," + (this.height/2+2) + ")" )
+
+        self.highlabel
+        .transition()
+          .delay(700)
+          .duration(700)
+          .attr("transform", "translate(90," + (0) + ")" )
+
+          self.lowlabel
+        .transition()
+          .delay(600)
+          .duration(800)
+          .attr("transform", "translate(330,-40)" )
 
       },
       shiftRidges(svg, days){
@@ -355,14 +369,14 @@ export default {
         var xAxisL = g => g
           .attr("transform", `translate(0,${this.height+5})`)
           .call(this.d3.axisBottom(xhalfL)
-              .tickValues([50, 143, 223, 313])
+              .tickValues([1, 93, 183, 273])
               .tickFormat(function(d,i) { return self.tickDates[i] })
               .tickSizeOuter(0).tickSize(0))
 
          var xAxisR = g => g
           .attr("transform", `translate(0,${this.height+5})`)
           .call(this.d3.axisBottom(xhalfR)
-              .tickValues([50, 143, 223, 313])
+              .tickValues([1, 93, 183, 273])
               .tickFormat(function(d,i) { return self.tickDates[i] })
               .tickSizeOuter(0).tickSize(0))
 
@@ -373,38 +387,38 @@ export default {
         // transform axes
         this.d3.select(".xaxis.ridge_2011")
         .transition()
-        .duration(1000)
-        .delay(2000)
+        .duration(300)
+        .delay(350)
         .call(xAxisL);
 
         this.d3.select(".xaxis.ridge_2012")
         .transition()
-        .duration(1000)
-        .delay(2000)
+        .duration(500)
+        .delay(250)
         .call(xAxisR);
 
         this.d3.select(".yaxis.ridge_2012")
         .transition()
-        .duration(1000)
-        .delay(2000)
+        .duration(700)
+        .delay(250)
         .call(yAxisTall);
 
         this.d3.select(".yaxis.ridge_2011")
         .transition()
-        .duration(1000)
-        .delay(2000)
+        .duration(500)
+        .delay(250)
         .call(yAxisTall);
 
         this.d3.selectAll("g.ridge_2011.curve")
         .transition()
-        .delay(2000)
-        .duration(1000)
+        .delay(270)
+        .duration(500)
         .attr("transform", "translate(0, 0) scale(.49, 1)")
 
          this.d3.selectAll("g.ridge_2012.curve")
         .transition()
-        .delay(2000)
-        .duration(1000)
+        .delay(250)
+        .duration(500)
         .attr("transform", "translate(270, 0) scale(.49, 1)")
 
       },
@@ -456,7 +470,7 @@ export default {
 
         this.group.append("path")
           .attr("fill", "none")
-          .attr("stroke",function(d) { return colorStack(d.key)})
+          .attr("stroke","dodgerblue")
           .attr("d", d => self.line(d.mmd))
           .attr("stroke-width", "1.5px");
 
@@ -471,7 +485,6 @@ export default {
           .x((d, i) => x(days[i]))
           .y0(0)
           .y1(d => z_swe(d))
-
 
 /*          this.group.append("path")
           .attr("fill", "grey")
@@ -524,6 +537,8 @@ export default {
   font-size: 16px;
   font-weight: 700;
   text-anchor: middle;
+  font-style: italic;
+  fill: rgb(165, 163, 163);
 }
 input[name="radiogroup1"] {
             display: none;
@@ -537,8 +552,8 @@ input[name="radiogroup1"] {
 
     input[name="radiogroup1"]:checked+label {
         /* style checked state as you like */
-        border: 7px solid orchid;
-        background-color: orchid;
+        border: 7px solid dodgerblue;
+        background-color: dodgerblue;
         color: white;
     }
 </style>

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -74,18 +74,19 @@
             id="mmd-line-both"
             xmlns="http://www.w3.org/2000/svg"
             xmlns:xlink="http://www.w3.org/1999/xlink"
-            viewBox="-50 -50 600 550"
+            viewBox="0 -50 550 520"
             aria-labelledby="page-title page-desc"
             width="100%"
+            height="auto"
           >
 
-            <text
-              x="90"
-              y="470"
+            <text class="yr-label"
+              x="150"
+              y="450"
             >High snow year</text>
-            <text
-              x="350"
-              y="470"
+            <text class="yr-label"
+              x="400"
+              y="450"
             >Low snow year</text>
           </svg>
         </div>
@@ -145,6 +146,7 @@ export default {
               ridge_o: 0.3,
               site_elev: [],
               site_sp: [],
+              tickDates: ["Oct", "Jan", "Apr", "July"],
         
 
               checkedData: ["mmd"],
@@ -258,17 +260,18 @@ export default {
 
         // define & style x &  y axes
         var xAxis = g => g
-          .attr("transform", `translate(0,${this.height+5})`)
+          .attr("transform", `translate(0,${this.height})`)
           .call(this.d3.axisBottom(x)
-              .ticks(this.width / 60)
-              .tickSizeOuter(0))
+              .tickValues([50, 143, 223, 313])
+              .tickFormat(function(d,i) { return self.tickDates[i] })
+              .tickSizeOuter(0).tickSize(0))
 
         var yAxis = g => g
           .attr("transform", `translate(${0},-2)`)
           .call(this.d3.axisLeft(y).tickSize(0).tickPadding(4))
         // append axes
-        svg.append("g").classed("xaxis", true).classed(ridge_class, true).call(xAxis);
-        svg.append("g").classed("yaxis", true).classed(ridge_class, true).call(yAxis);
+        svg.append("g").classed("xaxis", true).classed(ridge_class, true).call(xAxis).attr("font-style", "italic");
+        svg.append("g").classed("yaxis", true).classed(ridge_class, true).call(yAxis).attr("font-style", "italic");
 
         // define area chart parameters
         this.area = this.d3.area()
@@ -352,14 +355,16 @@ export default {
         var xAxisL = g => g
           .attr("transform", `translate(0,${this.height+5})`)
           .call(this.d3.axisBottom(xhalfL)
-              .ticks(this.width / 60)
-              .tickSizeOuter(0))
+              .tickValues([50, 143, 223, 313])
+              .tickFormat(function(d,i) { return self.tickDates[i] })
+              .tickSizeOuter(0).tickSize(0))
 
          var xAxisR = g => g
           .attr("transform", `translate(0,${this.height+5})`)
           .call(this.d3.axisBottom(xhalfR)
-              .ticks(this.width / 60)
-              .tickSizeOuter(0))
+              .tickValues([50, 143, 223, 313])
+              .tickFormat(function(d,i) { return self.tickDates[i] })
+              .tickSizeOuter(0).tickSize(0))
 
         var yAxisTall = g => g
           .attr("transform", `translate(${0},-2)`)
@@ -495,24 +500,30 @@ export default {
 }
 .maxWidth {
   width: 90vw;
+  margin-left: 5vw;
   max-width: 700px;
   margin: auto;
 }
-input {
-  margin-left: 20px;
-  margin-right: 5px;
-  display: inline-block;
-}
+
 .compare {
   border: 2px solid black;
   display: inline-block;
   font-size: 18px;
   text-align: center;
     padding: 5px 10px;
+    margin: auto;
 }
-
+/* #mmd-line-both {
+  margin: auto;
+  padding: 1em;
+} */
 .butt {
   padding: 5px 10px;
+}
+.yr-label {
+  font-size: 16px;
+  font-weight: 700;
+  text-anchor: middle;
 }
 input[name="radiogroup1"] {
             display: none;

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -97,8 +97,8 @@
     <label class="butt" for="rb1">timing</label>
     <input  class="butt" id="rb2" type="radio" name="radiogroup1">
     <label class="butt" for="rb2">magnitude</label>
-    <input class="butt" id="rb3" type="radio" name="radiogroup1">
-    <label class="butt" for="rb3">by elevation</label></h4>
+<!--     <input class="butt" id="rb3" type="radio" name="radiogroup1">
+    <label class="butt" for="rb3">by elevation</label> --></h4>
 </div>
       </div>
       </div>

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -4,21 +4,6 @@
     <!-- TAKEAWAY TITLE -->
     <template v-slot:takeAway>
       <h2>Changing snow in the west can have enormous impacts on water availability.</h2>
-      <!--    <div class="checks">
-        <input type="checkbox"
-               value="in_swe" 
-               v-model="checkedData" 
-               @change=""/>
-        <label for="in_swe">swe</label>     
-        </div>
-      <div class="checks">
-        <input type="checkbox"
-               value="mmd"
-               v-model="checkedData" 
-               @change=""/>
-        <label for="in_mmd">mmd</label>
-        <h3>checked: {{ checkedData }} </h3>
-        </div> -->
     </template>
     <!-- EXPLANATION -->
     <template v-slot:aboveExplanation>
@@ -26,9 +11,15 @@
         The differences between a high a low snow year illustrate the downstream effects of changing snow on water resources. For example, in 2011 snowmelt occurred ## days later than 2012.
         This was because of differences in the amount of snowpack between years - in 2011 peak SWE was  2x higher.  there were considerable difference in the magnitude of SWE and subsequently discharge at the shown locations in the Upper Colorado river basin.
         With 2 times higher snowpack shown int he line chart. 
-        Because of less snowpack, melt rates were faster and SM50 occurred between ## to ## days earlier at these sites.
-        Elevation.
       </p>
+      <div class="compare">
+        <h4>Compare: <input type="radio" id="one" value="One" v-model="picked">
+          <label for="one">timing</label>   
+        <input type="radio" id="two" value="Two" v-model="picked">
+          <label for="two">magnitude</label>
+        <input type="radio" id="two" value="Two" v-model="picked">   
+          <label for="three">elevation</label></h4>
+        </div>
     </template>
     <!-- FIGURES -->
     <template v-slot:figures>
@@ -498,5 +489,9 @@ export default {
 .maxWidth {
   max-width: 50vw;
 }
-
+input {
+  margin-left: 20px;
+  margin-right: 5px;
+  display: inline-block;
+}
 </style>


### PR DESCRIPTION
Changes made:
-----------
the ridge plots now transition their layout between "timing", magnitude", and "by elevation". Code could be more efficient but it works.
![ridgedance](https://user-images.githubusercontent.com/17803537/112991630-f500f000-912c-11eb-95a8-b6220694e896.gif)


It's cool but needs more annotations, and to have the SWE curve added on as well. Proud of my toggle button!

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
