### PR TITLE
smaller take away headerlines

### DIFF
--- a/src/components/VizSection.vue
+++ b/src/components/VizSection.vue
@@ -56,7 +56,9 @@ $border: 10px solid #000;
 }
 /*#####TAKE AWAY#####*/
 .takeAway{
-    font-size: 1.4em;
+    h2{
+      font-size: 1.4em;
+    }
     margin: 0 auto $spacing auto;
     max-width: 700px;
     font-weight: 800;
@@ -132,7 +134,9 @@ $border: 10px solid #000;
 }
 @media screen and (min-width: 1024px){
   .takeAway{
-    font-size: 1.7em
+    h2{
+      font-size: 1.7em
+    }
   }
   /*#####CUSTOMIZATION CLASSES#####*/
     .group{


### PR DESCRIPTION
Changes made:
-----------
Description

We had competing h2 CSS declarations, turned the take away css to a more specific declaration and feel like the sizing is much better now.

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
