### PR TITLE
line chart not cut off

### DIFF
--- a/src/components/LineChart.vue
+++ b/src/components/LineChart.vue
@@ -495,8 +495,8 @@ export default {
 
 <style lang="scss" scoped>
     svg {
-        width: 800px;
-        height: 500px;
+        width: 100%;
+        height: 100%;
     }
 
    .axis-tick, .annotation-line {

--- a/src/components/SWE.vue
+++ b/src/components/SWE.vue
@@ -88,5 +88,6 @@ export default {
   #swe-chart-container {
     width: 100%;
     height: auto;
+    margin-bottom: 0;
   }
 </style>

--- a/src/components/VizSection.vue
+++ b/src/components/VizSection.vue
@@ -115,9 +115,6 @@ $border: 10px solid #000;
 }
 .single{
     text-align: center;
-    figure{
-        min-height: 300px;
-    }
 }
 .group{
     /* prevent too large mobile graphs from creating a x scroll */


### PR DESCRIPTION
Changes made:
-----------
Description

Line chart is no longer cut off on mobile.  It is pretty hard to decipher now, but not much I can do on my end to fix that.  Would need a rethink of how to display this same data in mobile form.  

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
