### PR TITLE
takeAway prop added to vizsection component

### DIFF
--- a/src/components/MeasuringSWE.vue
+++ b/src/components/MeasuringSWE.vue
@@ -1,10 +1,9 @@
 <template>
   <!---VizSection-->
-  <VizSection id="measuring-swe">
-    <!-- TAKEAWAY TITLE -->
-    <template v-slot:takeAway><!-- 
-      <h2>The USGS has been studying the connection between snowpack and stream flow for decades.</h2> -->
-    </template>
+  <VizSection
+    id="measuring-swe"
+    :take-away="false"
+  >
     <template v-slot:aboveExplanation>
       <p>The USGS has been advancing snow science through both measuring and modeling snowpack, and linking these results to streamflow.  Explain what SNOTEL sites are here, as well as the other field data collection techniques here.</p>
       <p>Measuring - Snow monitoring stations with meteorological data – NGWOS. NRCS and SnoTEL. Remote sensing – snow persistence.</p>

--- a/src/components/SNTLmap.vue
+++ b/src/components/SNTLmap.vue
@@ -2,11 +2,8 @@
   <!---VizSection-->
   <VizSection
     id="SNTLMap"
+    :take-away="false"
   >
-    <!-- TAKEAWAY TITLE -->
-    <template v-slot:takeAway>
-     <!--  <h2>Snowmelt season has already begun.</h2> -->
-    </template>    
     <!-- EXPLANATION -->
     <template v-slot:aboveExplanation>
       <!--   <p class="byline" >

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -1,14 +1,13 @@
 <template>
   <!---VizSection-->
-  <VizSection id="firstSection">
-    <!-- TAKEAWAY TITLE -->
-    <template v-slot:takeAway>
-      <!-- <h2>Changing snow in the west can have enormous impacts on water availability.</h2> -->
-    </template>
+  <VizSection
+    id="firstSection"
+    :take-away="false"
+  >
     <!-- EXPLANATION -->
     <template v-slot:aboveExplanation>
       <p>
-         The differences between a high a low snow year illustrate the downstream effects of changing snow on water resources. For example, between 2011 and 2012 there was a two-fold difference in snowpack in some parts of the Upper Colorado River Basin which corresponded to differences in the timing of snowmelt and water availability downstream. 
+        The differences between a high a low snow year illustrate the downstream effects of changing snow on water resources. For example, between 2011 and 2012 there was a two-fold difference in snowpack in some parts of the Upper Colorado River Basin which corresponded to differences in the timing of snowmelt and water availability downstream. 
       </p>
     </template>
     <!-- FIGURES -->

--- a/src/components/VizSection.vue
+++ b/src/components/VizSection.vue
@@ -1,7 +1,10 @@
 <template>
   <section class="vizSection">
     <div class="vizSectionContent">
-      <div class="takeAway">
+      <div
+        v-if="takeAway"
+        class="takeAway"
+      >
         <slot name="takeAway">
           <!--    Take Away Title -->
         </slot>
@@ -35,6 +38,10 @@
 export default {
     name: "VizSection",
     props:{
+        takeAway:{
+          type: Boolean,
+          default: true
+        },
         figCaption:{
           type: Boolean,
           default: true


### PR DESCRIPTION
Changes made:
-----------
Description

Added a takeaway prop, so when you don't want that part of the vizsection component just set it to false on that specific component.  As a heads up I had previously done this for both the figures and figure captions.  This is probably one of the most customizable components I've ever made, kinda cool learning how to do this stuff.

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
