### PR TITLE
add swe to ridgeline

### DIFF
--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -306,8 +306,8 @@ export default {
 
         // set chart - separate for each year, using 2011 for max values to set the scales
         //  first draw is MMD
-        self.initRidges(this.svgboth, 'ridge_2011', data.mmd11, data.days, 0, x_long, this.margin, this.height/2-5);
-        self.initRidges(this.svgboth, 'ridge_2012', data.mmd12, data.days, 0, x_long, this.height/2+mar+2,  this.height+2);
+        self.initRidges(this.svgboth, 'ridge_2011', data.mmd11, data.days, 0, x_long, 0, this.height/2);
+        self.initRidges(this.svgboth, 'ridge_2012', data.mmd12, data.days, 0, x_long, this.height/2,  this.height);
 
       },
       initRidges(svg, ridge_class, data_nest, days, x_start, x_end,  y_start, y_end){
@@ -348,8 +348,8 @@ export default {
 
         // append axes
         svg.append("g").classed("xaxis", true).classed(ridge_class, true).call(this.xAxis).attr("font-style", "italic");
-        svg.append("g").classed("yaxis", true).classed(ridge_class, true).call(this.yAxis_mmd).attr("font-style", "italic").attr("color", this.color_mmd);
-        svg.append("g").classed("yaxis", true).classed(ridge_class, true).call(this.yAxis_swe).attr("font-style", "italic").attr("color", this.color_swe);
+        svg.append("g").classed("yaxis", true).classed(ridge_class, true).call(this.yAxis_mmd).attr("font-style", "italic").attr("color", this.color_mmd).classed("mmd", true);
+        svg.append("g").classed("yaxis", true).classed(ridge_class, true).call(this.yAxis_swe).attr("font-style", "italic").attr("color", this.color_swe).classed("swe", true);
 
         // define area chart parameters
         this.area_mmd = this.d3.area()
@@ -493,12 +493,12 @@ export default {
         this.fast.transition().delay(100).duration(300).attr("opacity",1)
 
         // transform axes
-        self.transAxis(this.x11, 350, 300, self.xAxis, 0, this.height/2-5, 1, 1)
+        self.transAxis(this.x11, 350, 300, self.xAxis, 0, this.height/2, 1, 1)
         self.transAxis(this.x12, 250, 500, self.xAxis, 0, this.height, 1, 1)
-        self.transAxis(this.y11_swe, 350, 300, self.yAxis_swe, 0, -this.height/2-5, 1, 1)
+        self.transAxis(this.y11_swe, 350, 300, self.yAxis_swe, 0, -this.height/2, 1, 1)
         self.transAxis(this.y12_swe, 250, 500, self.yAxis_swe, 0, 0, 1, 1)
-        self.transAxis(this.y11_mmd, 350, 300, self.yAxis_mmd, 0, -this.height/2-5, 1, 1)
-        self.transAxis(this.y12_mmd, 250, 500, self.yAxis_mmd, 0, 0, 1, 1)
+        self.transAxis(this.y11_mmd, 350, 300, self.yAxis_mmd, this.width-75, -this.height/2, 1, 1)
+        self.transAxis(this.y12_mmd, 250, 500, self.yAxis_mmd, this.width-75, 0, 1, 1)
 
         // stretch ridges to full x and y extent
         self.transPosition(this.d3.selectAll("g.ridge_2011.curve"), 270, 500,  0, 0, 1, 1)
@@ -533,14 +533,14 @@ export default {
           .transition()
           .delay(function(d,i) { return i*15 })
           .duration(1100)
-          .attr("transform", "translate(0," + (this.height/2+2) + ")" )
+          .attr("transform", "translate(0," + (this.height/2) + ")" )
 
         this.ridge11
         .transition()
         .delay(200)
         .duration(400)
         .attr("transform", function(d, i) { 
-          return "translate(0," + (5+i*0)  + ") scale(1, 1)"
+          return "translate(0," + (0+i*0)  + ") scale(1, 1)"
         })
 
         this.ridge12
@@ -550,22 +550,47 @@ export default {
         .attr("transform", function(d, i) { 
           return "translate(0," + (0) + ") scale(1, 1)"
         })
+
+        // y mmd
+        var y_mmd = this.d3.scaleLinear()
+          .domain([30, 0]).nice()
+          .range([this.height/2, this.height])
+
+          // y swe
+        var y_swe = this.d3.scaleLinear()
+          .domain([1100, 0]).nice()
+          .range([this.height/2, this.height])
+
+      // mmd axes
+        var y_mmd_low = g => g
+          .attr("transform", `translate(${this.width-75},0)`)
+          .call(this.d3.axisRight(y_mmd).tickSize(0).tickPadding(4).tickValues([0, 10, 20, 30]))
+
+          // mmd axes
+        var y_swe_low = g => g
+          .attr("transform", `translate(${0},0)`)
+          .call(this.d3.axisLeft(y_swe).tickSize(0).tickPadding(4).tickValues([0, 250, 500, 750, 1000]))
         
         // move labels
         //self.transPosition(self.lowlabel, 600, 800, 310, -50, 1,1)
         //self.transPosition(self.highlabel, 700, 700, 80, 40, 1, 1)  
         self.transFade(this.d3.selectAll("g.yaxis g"), 300, 500, 1)
 
-        // transform axes
-        self.transAxis(this.y11_mmd, 450, 500, self.yAxis_mmd, 0, 0, 1, 1)
-        self.transAxis(this.y12_mmd, 450, 500, self.yAxis_mmd,0, 0, 1, 1)
-        self.transAxis(this.y11_swe, 450, 500, self.yAxis_swe, 0, 0, 1, 1)
-        self.transAxis(this.y12_swe, 450, 500, self.yAxis_swe, 0, 0, 1, 1)
+         // transform axes
+        self.transAxis(this.y11_mmd, 450, 500, y_mmd_low, this.width-75,0, 1, 1)
+        self.transAxis(this.y12_mmd, 450, 500, y_mmd_low,this.width-75, 0,1, 1)
+        self.transAxis(this.y11_swe, 450, 500, y_swe_low, 0, 0, 1, 1)
+        self.transAxis(this.y12_swe, 450, 500, y_swe_low, 0, 0, 1, 1) 
 
-        this.lowlabel.transition().delay(100).duration(300).attr("opacity",0)
-        this.highlabel.transition().delay(100).duration(300).attr("opacity",0)
-        this.lowel.transition().delay(100).duration(300).attr("opacity",1)
-        this.highel.transition().delay(100).duration(300).attr("opacity",1)
+
+/*         this.y11_mmd.transition().duration(100).attr("opacity", 0)
+         this.y12_mmd.transition().duration(100).attr("opacity", 0) */
+
+
+        this.lowlabel.transition().delay(100).duration(300).attr("opacity",1)
+        this.highlabel.transition().delay(100).duration(300).attr("opacity",1)
+        this.lowel.transition().delay(100).duration(300).attr("opacity",0)
+        this.highel.transition().delay(100).duration(300).attr("opacity",0)
         this.slow.transition().delay(100).duration(300).attr("opacity",0)
         this.fast.transition().delay(100).duration(300).attr("opacity",0)
 
@@ -612,8 +637,10 @@ export default {
         this.fast.transition().delay(100).duration(300).attr("opacity",0)
 
        // transform axes
-        self.transAxis(this.y11_swe, 350, 500, yAxisTall, 0, 0, 1, 1)
-        self.transAxis(this.y12_swe, 350, 500, yAxisTall, 0, 0, 1, 1)
+        self.transAxis(this.y11_swe, 350, 500, self.yAxis_swe, 0, -100, 1, 1)
+        self.transAxis(this.y12_swe, 350, 500, self.yAxis_swe, 0, 0, 1, 1) 
+        self.transAxis(this.y11_mmd, 350, 500, self.yAxis_mmd, this.width-75, -100, 1, 1)
+        self.transAxis(this.y12_mmd, 350, 500, self.yAxis_mmd, this.width-75, 0, 1, 1) 
 
         self.transFade(this.d3.selectAll("g.yaxis g"), 300, 400, 0)
       },
@@ -631,33 +658,28 @@ export default {
           .domain([1,365])
           .range([mid+5, x_long]);
 
-        var y = this.d3.scaleLinear()
-          .domain([25, 0]).nice()
-          .range([this.height/2+mar, this.height])
-
+        
         var xAxisL = g => g
-          .attr("transform", `translate(0,${this.height+5})`)
+          .attr("transform", `translate(0,${this.height})`)
           .call(this.d3.axisBottom(xhalfL)
               .tickValues([1, 93, 183, 273])
               .tickFormat(function(d,i) { return self.tickDates[i] })
               .tickSizeOuter(0).tickSize(0))
 
          var xAxisR = g => g
-          .attr("transform", `translate(0,${this.height+5})`)
+          .attr("transform", `translate(0,${this.height})`)
           .call(this.d3.axisBottom(xhalfR)
               .tickValues([1, 93, 183, 273])
               .tickFormat(function(d,i) { return self.tickDates[i] })
               .tickSizeOuter(0).tickSize(0))
 
-        var yAxisTall = g => g
-          .attr("transform", `translate(${0},-2)`)
-          .call(this.d3.axisLeft(y).tickSize(0).tickPadding(4))
-
-        // transform axes
+   // transform axes
         self.transAxis(this.x11, 350, 400, xAxisL, 0, this.height, 1, 1)
         self.transAxis(this.x12, 250, 500, xAxisR, 0, this.height, 1, 1)
-        self.transAxis(this.y11_swe, 350, 500, yAxisTall, 0, 0, 1, 1)
-        self.transAxis(this.y12_swe, 350, 400, yAxisTall, 0, 0, 1, 1)
+         /*    self.transAxis(this.y11_swe, 350, 500, self.yAxis_swe, 0, this.height/2, 1, 1)
+        self.transAxis(this.y12_swe, 350, 400, self.yAxis_swe, 0, 0, 1, 1)
+        self.transAxis(this.y11_mmd, 350, 500, self.yAxis_mmd, this.width-75, this.height/2, 1, 1)
+        self.transAxis(this.y12_mmd, 350, 400, self.yAxis_mmd, this.width-75, 0, 1, 1) */
 
         this.d3.selectAll("g.ridge_2011.curve")
         .transition()

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -195,8 +195,10 @@ export default {
               yAxis_swe: null,
               x11: null,
               x12: null,
-              y11: null,
-              y12: null,
+              y11_swe: null,
+              y12_swe: null,
+              y11_mmd: null,
+              y12_mmd: null,
               ridge11:null,
               ridge12: null,
 
@@ -310,12 +312,12 @@ export default {
 
       // mmd axes
         this.yAxis_mmd = g => g
-          .attr("transform", `translate(${0},-2)`)
-          .call(this.d3.axisLeft(y_mmd).tickSize(0).tickPadding(4))
+          .attr("transform", `translate(${this.width-75},0)`)
+          .call(this.d3.axisRight(y_mmd).tickSize(0).tickPadding(4))
 
           // mmd axes
         this.yAxis_swe = g => g
-          .attr("transform", `translate(${0},-2)`)
+          .attr("transform", `translate(${0},0)`)
           .call(this.d3.axisLeft(y_swe).tickSize(0).tickPadding(4))
 
         // append axes
@@ -361,7 +363,8 @@ export default {
           .attr("stroke", this.color_mmd)
           .attr("opacity", 0.7)
           .attr("class", function(d) { return d.key })
-          .classed("ridge", true);
+          .classed("ridge", true)
+          .classed("mmd", true);
 
          // draw SWE curves
         this.group.append("path")
@@ -372,7 +375,8 @@ export default {
           .attr("stroke", this.color_swe)
           .attr("opacity", 0.7)
           .attr("class", function(d) { return d.key })
-          .classed("ridge", true);
+          .classed("ridge", true)
+          .classed("swe", true);
 
         this.y2011 = this.svgboth.selectAll("g.ridge_2011") // ridge group
         this.y2012 = this.svgboth.selectAll("g.ridge_2012")
@@ -380,8 +384,10 @@ export default {
         this.ridge12 = this.d3.selectAll("g.ridge_2012.curve g") 
         this.highlabel = this.svgboth.select("#wy11") // high and low snow labels
         this.lowlabel = this.svgboth.select("#wy12")
-        this.y11 = this.d3.select(".yaxis.ridge_2011") // axes
-        this.y12 = this.d3.select(".yaxis.ridge_2012")
+        this.y11_swe = this.d3.select(".yaxis.ridge_2011.swe") // axes
+        this.y12_swe = this.d3.select(".yaxis.ridge_2012.swe")
+        this.y11_mmd = this.d3.select(".yaxis.ridge_2011.mmd") // axes
+        this.y12_mmd = this.d3.select(".yaxis.ridge_2012.mmd")
         this.x11 = this.d3.select(".xaxis.ridge_2011")
         this.x12 = this.d3.select(".xaxis.ridge_2012")
 
@@ -443,8 +449,8 @@ export default {
         // transform axes
         self.transAxis(this.x11, 350, 300, self.xAxis, 0, this.height/2-5, 1, 1)
         self.transAxis(this.x12, 250, 500, self.xAxis, 0, this.height, 1, 1)
-        self.transAxis(this.y11, 350, 300, self.yAxis, 0, -this.height/2-5, 1, 1)
-        self.transAxis(this.y12, 250, 500, self.yAxis, 0, 0, 1, 1)
+        self.transAxis(this.y11_swe, 350, 300, self.yAxis, 0, -this.height/2-5, 1, 1)
+        self.transAxis(this.y12_swe, 250, 500, self.yAxis, 0, 0, 1, 1)
 
         // stretch ridges to full x and y extent
         self.transPosition(this.d3.selectAll("g.ridge_2011.curve"), 270, 500,  0, 0, 1, 1)
@@ -503,8 +509,10 @@ export default {
         self.transFade(this.d3.selectAll("g.yaxis g"), 300, 500, 1)
 
         // transform axes
-        self.transAxis(this.y11, 450, 500, self.yAxis, 0, 0, 1, 1)
-        self.transAxis(this.y12, 450, 500, self.yAxis, 0, 0, 1, 1)
+        self.transAxis(this.y11_mmd, 450, 500, self.yAxis_mmd, 0, 0, 1, 1)
+        self.transAxis(this.y12_mmd, 450, 500, self.yAxis_mmd,0, 0, 1, 1)
+        self.transAxis(this.y11_swe, 450, 500, self.yAxis_swe, 0, 0, 1, 1)
+        self.transAxis(this.y12_swe, 450, 500, self.yAxis_swe, 0, 0, 1, 1)
 
       },
       toElevation(){
@@ -543,8 +551,8 @@ export default {
         self.transPosition(self.lowlabel, 450, 500, 320, -300, 1, 1)
 
        // transform axes
-        self.transAxis(this.y11, 350, 500, yAxisTall, 0, 0, 1, 1)
-        self.transAxis(this.y12, 350, 500, yAxisTall, 0, 0, 1, 1)
+        self.transAxis(this.y11_swe, 350, 500, yAxisTall, 0, 0, 1, 1)
+        self.transAxis(this.y12_swe, 350, 500, yAxisTall, 0, 0, 1, 1)
 
         self.transFade(this.d3.selectAll("g.yaxis g"), 300, 400, 0)
       },
@@ -587,8 +595,8 @@ export default {
         // transform axes
         self.transAxis(this.x11, 350, 400, xAxisL, 0, this.height, 1, 1)
         self.transAxis(this.x12, 250, 500, xAxisR, 0, this.height, 1, 1)
-        self.transAxis(this.y11, 350, 500, yAxisTall, 0, 0, 1, 1)
-        self.transAxis(this.y12, 350, 400, yAxisTall, 0, 0, 1, 1)
+        self.transAxis(this.y11_swe, 350, 500, yAxisTall, 0, 0, 1, 1)
+        self.transAxis(this.y12_swe, 350, 400, yAxisTall, 0, 0, 1, 1)
 
         this.d3.selectAll("g.ridge_2011.curve")
         .transition()

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -79,17 +79,43 @@
           >
 
             <text
-              id="wy11"
+              id="melt11"
               class="yr-label"
-              x="50"
-              y="175"
-            >High snow</text>
+              x="200"
+              y="20"
+            >later and <tspan x="200" y="40px">faster melt</tspan></text>
             <text
-              id="wy12"
+              id="melt12"
               class="yr-label"
-              x="50"
-              y="375"
-            >Low snow</text>
+              x="300"
+              y="290"
+            >earlier and <tspan x="300" y="310px">longer melt</tspan></text>
+
+            <text
+              id="peak11"
+              class="yr-label"
+              x="80"
+              y="230"
+            >high snow</text>
+            <text
+              id="peak12"
+              class="yr-label"
+              x="350"
+              y="320"
+            >low snow</text>
+            
+            <text
+              id="el11"
+              class="yr-label"
+              x="20"
+              y="20"
+            >high elevation</text>
+            <text
+              id="el12"
+              class="yr-label"
+              x="-20"
+              y="390"
+            >low</text>
           </svg>
         </div>
         <div class="compare">
@@ -294,12 +320,12 @@ export default {
 
         // y mmd
         var y_mmd = this.d3.scaleLinear()
-          .domain([25, 0]).nice()
+          .domain([30, 0]).nice()
           .range([y_start, y_end])
 
           // y swe
         var y_swe = this.d3.scaleLinear()
-          .domain([1000, 0]).nice()
+          .domain([1100, 0]).nice()
           .range([y_start, y_end])
 
         // define & style x &  y axes
@@ -313,12 +339,12 @@ export default {
       // mmd axes
         this.yAxis_mmd = g => g
           .attr("transform", `translate(${this.width-75},0)`)
-          .call(this.d3.axisRight(y_mmd).tickSize(0).tickPadding(4))
+          .call(this.d3.axisRight(y_mmd).tickSize(0).tickPadding(4).tickValues([0, 10, 20, 30]))
 
           // mmd axes
         this.yAxis_swe = g => g
           .attr("transform", `translate(${0},0)`)
-          .call(this.d3.axisLeft(y_swe).tickSize(0).tickPadding(4))
+          .call(this.d3.axisLeft(y_swe).tickSize(0).tickPadding(4).tickValues([0, 250, 500, 750, 1000]))
 
         // append axes
         svg.append("g").classed("xaxis", true).classed(ridge_class, true).call(this.xAxis).attr("font-style", "italic");
@@ -382,14 +408,27 @@ export default {
         this.y2012 = this.svgboth.selectAll("g.ridge_2012")
         this.ridge11 = this.d3.selectAll("g.ridge_2011.curve g") // ridge themselves for staggered animation
         this.ridge12 = this.d3.selectAll("g.ridge_2012.curve g") 
-        this.highlabel = this.svgboth.select("#wy11") // high and low snow labels
-        this.lowlabel = this.svgboth.select("#wy12")
+
+        this.highlabel = this.svgboth.select("text#peak11") // high and low snow labels
+        this.lowlabel = this.svgboth.select("text#peak12")
+        this.highel = this.svgboth.select("text#el11") // high and low snow labels
+        this.lowel = this.svgboth.select("text#el12")
+        this.fast = this.svgboth.select("text#melt11") // high and low snow labels
+        this.slow = this.svgboth.select("text#melt12")    
+
         this.y11_swe = this.d3.select(".yaxis.ridge_2011.swe") // axes
         this.y12_swe = this.d3.select(".yaxis.ridge_2012.swe")
         this.y11_mmd = this.d3.select(".yaxis.ridge_2011.mmd") // axes
         this.y12_mmd = this.d3.select(".yaxis.ridge_2012.mmd")
         this.x11 = this.d3.select(".xaxis.ridge_2011")
         this.x12 = this.d3.select(".xaxis.ridge_2012")
+
+        this.lowlabel.transition().duration(0).attr("opacity",0)
+        this.highlabel.transition().duration(0).attr("opacity",0)
+        this.lowel.transition().duration(0).attr("opacity",0)
+        this.highel.transition().duration(0).attr("opacity",0)
+        this.slow.transition().duration(0).attr("opacity",1)
+        this.fast.transition().duration(0).attr("opacity",1)
 
       },
       changePos(){
@@ -443,14 +482,23 @@ export default {
           .attr("transform", "translate(0," + (0) + ")" )
 
         // move labels
-        self.transPosition(self.lowlabel, 600, 800, 0, 0, 1, 1)
-        self.transPosition(self.highlabel, 700, 700, 0, 0, 1, 1)
+        //self.transPosition(self.lowlabel, 600, 800, 0, 0, 1, 1)
+        //self.transPosition(self.highlabel, 700, 700, 0, 0, 1, 1)
+
+        this.lowlabel.transition().delay(100).duration(300).attr("opacity",0)
+        this.highlabel.transition().delay(100).duration(300).attr("opacity",0)
+        this.lowel.transition().delay(100).duration(300).attr("opacity",0)
+        this.highel.transition().delay(100).duration(300).attr("opacity",0)
+        this.slow.transition().delay(100).duration(300).attr("opacity",1)
+        this.fast.transition().delay(100).duration(300).attr("opacity",1)
 
         // transform axes
         self.transAxis(this.x11, 350, 300, self.xAxis, 0, this.height/2-5, 1, 1)
         self.transAxis(this.x12, 250, 500, self.xAxis, 0, this.height, 1, 1)
-        self.transAxis(this.y11_swe, 350, 300, self.yAxis, 0, -this.height/2-5, 1, 1)
-        self.transAxis(this.y12_swe, 250, 500, self.yAxis, 0, 0, 1, 1)
+        self.transAxis(this.y11_swe, 350, 300, self.yAxis_swe, 0, -this.height/2-5, 1, 1)
+        self.transAxis(this.y12_swe, 250, 500, self.yAxis_swe, 0, 0, 1, 1)
+        self.transAxis(this.y11_mmd, 350, 300, self.yAxis_mmd, 0, -this.height/2-5, 1, 1)
+        self.transAxis(this.y12_mmd, 250, 500, self.yAxis_mmd, 0, 0, 1, 1)
 
         // stretch ridges to full x and y extent
         self.transPosition(this.d3.selectAll("g.ridge_2011.curve"), 270, 500,  0, 0, 1, 1)
@@ -504,8 +552,8 @@ export default {
         })
         
         // move labels
-        self.transPosition(self.lowlabel, 600, 800, 330, -40, 1,1)
-        self.transPosition(self.highlabel, 700, 700, 90, 0, 1, 1)  
+        //self.transPosition(self.lowlabel, 600, 800, 310, -50, 1,1)
+        //self.transPosition(self.highlabel, 700, 700, 80, 40, 1, 1)  
         self.transFade(this.d3.selectAll("g.yaxis g"), 300, 500, 1)
 
         // transform axes
@@ -513,6 +561,13 @@ export default {
         self.transAxis(this.y12_mmd, 450, 500, self.yAxis_mmd,0, 0, 1, 1)
         self.transAxis(this.y11_swe, 450, 500, self.yAxis_swe, 0, 0, 1, 1)
         self.transAxis(this.y12_swe, 450, 500, self.yAxis_swe, 0, 0, 1, 1)
+
+        this.lowlabel.transition().delay(100).duration(300).attr("opacity",0)
+        this.highlabel.transition().delay(100).duration(300).attr("opacity",0)
+        this.lowel.transition().delay(100).duration(300).attr("opacity",1)
+        this.highel.transition().delay(100).duration(300).attr("opacity",1)
+        this.slow.transition().delay(100).duration(300).attr("opacity",0)
+        this.fast.transition().delay(100).duration(300).attr("opacity",0)
 
       },
       toElevation(){
@@ -547,8 +602,14 @@ export default {
           .call(this.d3.axisLeft(y).tickSize(0).tickPadding(4))
 
         // move labels
-        self.transPosition(self.highlabel, 350, 600, 20, -100, 1, 1)
-        self.transPosition(self.lowlabel, 450, 500, 320, -300, 1, 1)
+        //self.transPosition(self.highlabel, 350, 600, 20, -100, 1, 1)
+        //self.transPosition(self.lowlabel, 450, 500, 320, -300, 1, 1)
+        this.lowlabel.transition().delay(100).duration(300).attr("opacity",0)
+        this.highlabel.transition().delay(100).duration(300).attr("opacity",0)
+        this.lowel.transition().delay(100).duration(300).attr("opacity",1)
+        this.highel.transition().delay(100).duration(300).attr("opacity",1)
+        this.slow.transition().delay(100).duration(300).attr("opacity",0)
+        this.fast.transition().delay(100).duration(300).attr("opacity",0)
 
        // transform axes
         self.transAxis(this.y11_swe, 350, 500, yAxisTall, 0, 0, 1, 1)


### PR DESCRIPTION
Changes made:
-----------
Plus integrating the axis transitions and adding some annotations. It looks funny on the elevation part now, would probably be better if they were filled?

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
