### PR TITLE
footer caption bug fix

### DIFF
--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -78,7 +78,7 @@
     </Chapter>
     
     <References v-if="checkIfSplashIsRendered" />
-    <Methods  v-if="checkIfSplashIsRendered" />
+    <Methods v-if="checkIfSplashIsRendered" />
   </div>
 </template>
 
@@ -118,7 +118,7 @@ export default {
       //Wait for page to load then run this function
       window.addEventListener("load", function(){
         self.findCarouselContainers();
-      })
+      });
     },
     updated(){
       this.lazyLoadImages();
@@ -191,7 +191,18 @@ export default {
 
         imgContainer.addEventListener("click", function(e){
           self.switchCaptionText(title);
-        })
+        });
+        //Add arrow click funtionality
+        document.addEventListener("keydown", function(e){
+          //Make sure its either right or left arrow keys
+          if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+            //only do something if imgcontainer exists
+            if(imgContainer){
+              //Switch caption
+              self.switchCaptionText(title);
+            }
+          }
+        });
       },
       switchCaptionText(text){
         const caption = document.querySelector(".caption");

--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -178,6 +178,19 @@ export default {
         const self = this;
         const imgContainer = document.querySelector(".fullscreen-v-img");
         const title = document.querySelector(".title-v-img");
+        const img = document.querySelector(".content-v-img img");
+
+        //Mutation observer
+        //If img src changes, update caption
+        const observer = new MutationObserver((changes) => {
+          changes.forEach(change => {
+            if(change.attributeName.includes('src')){
+              self.switchCaptionText(title);
+            }
+          })
+        })
+        //Telling observer what to observe
+        observer.observe(img, {attributes: true});
       
         if(e.target.classList.contains("sliderImage")){
           const captionHTML = `
@@ -188,21 +201,6 @@ export default {
             </div>`;
           imgContainer.insertAdjacentHTML("afterbegin", captionHTML);
         }
-
-        imgContainer.addEventListener("click", function(e){
-          self.switchCaptionText(title);
-        });
-        //Add arrow click funtionality
-        document.addEventListener("keydown", function(e){
-          //Make sure its either right or left arrow keys
-          if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
-            //only do something if imgcontainer exists
-            if(imgContainer){
-              //Switch caption
-              self.switchCaptionText(title);
-            }
-          }
-        });
       },
       switchCaptionText(text){
         const caption = document.querySelector(".caption");


### PR DESCRIPTION
Changes made:
-----------
Description

Replaces previous functionality with a mutation observer.  We watch the img inside the full img container, and if its src changes, we switch the caption.  So this covers clicks and arrow keys, basically any things that changes the src fires the function.  

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
