### PR TITLE
Splash Source tweaking

### DIFF
--- a/src/components/Splash.vue
+++ b/src/components/Splash.vue
@@ -1,9 +1,13 @@
 <template>
   <div class="splash">
     <div class="splashTitle">
-      <h1 id="title">From Snow to Flow</h1>
-      <h2 id="subtitle">What changing snowmelt means for western water</h2>
-     <!--  <p>U.S. Geological Survey, Water Mission Area</p> -->
+      <h1 id="title">
+        From Snow to Flow
+      </h1>
+      <h2 id="subtitle">
+        What changing snowmelt means for western water
+      </h2>
+      <!--  <p>U.S. Geological Survey, Water Mission Area</p> -->
     </div>
     <!-- <div class="splashOverlay" /> -->
     <div
@@ -12,7 +16,7 @@
       data-depth="0.10"
     >
       <picture>
-<!--         <source srcset="@/assets/titleImages/splash/mountainMG.png"> -->
+        <!--         <source srcset="@/assets/titleImages/splash/mountainMG.png"> -->
         <!-- Most compressed -->
         <source
           type="image/webp"
@@ -52,7 +56,7 @@
     >
       <picture>
         <!-- Not sure what the browser wants to do with this first one, but it's the largest original -->
-<!--         <source srcset="@/assets/titleImages/splash/frozen-lakeFG.png"> -->
+        <!--         <source srcset="@/assets/titleImages/splash/frozen-lakeFG.png"> -->
         <!-- Most compressed -->
         <source
           type="image/webp"
@@ -92,7 +96,7 @@
     >
       <picture>
         <!-- Not sure what the browser wants to do with this first one, but it's the largest original -->
-<!--         <source srcset="@/assets/titleImages/splash/people.png"> -->
+        <!--         <source srcset="@/assets/titleImages/splash/people.png"> -->
         <!-- Most compressed -->
         <source
           type="image/webp"
@@ -170,7 +174,7 @@
     >
       <picture>
         <!-- Not sure what the browser wants to do with this first one, but it's the largest original -->
-     <!--    <source srcset="@/assets/titleImages/splash/more-clouds.png"> -->
+        <!--    <source srcset="@/assets/titleImages/splash/more-clouds.png"> -->
         <!-- Most compressed -->
         <source
           type="image/webp"
@@ -235,7 +239,7 @@ export default {
                         .fromTo("#clouds", {yPercent: 20}, {yPercent: -10}, 0)
                         .fromTo("#people", {yPercent: 17}, {yPercent: -11}, 0)
                         .fromTo("#water", {yPercent: 15}, {yPercent: -10}, 0)
-                        .fromTo("#mountains", {yPercent: 10}, {yPercent: -2}, 0)
+                        .fromTo("#mountains", {yPercent: 0}, {yPercent: -2}, 0)
                     },
                     "(min-width: 2620px)": function(){
                         self.$gsap.timeline({

--- a/src/components/Splash.vue
+++ b/src/components/Splash.vue
@@ -24,17 +24,17 @@
         > 
         <!-- Smallest Screen -->
         <source
-          media="(min-width: 350px)"
+          media="(min-width: 350px) and (max-width: 499px)"
           srcset="@/assets/titleImages/splash/mountainMG-sm.png"
         >
         <!-- Medium Screen -->
         <source
-          media="(min-width: 500px)"
+          media="(min-width: 500px) and (max-width: 799px)"
           srcset="@/assets/titleImages/splash/mountainMG-m.png"
         >
         <!-- Large screen -->
         <source
-          media="(min-width: 800px)"
+          media="(min-width: 800px) and (max-width: 1199px)"
           srcset="@/assets/titleImages/splash/mountainMG-l.png"
         >
         <!-- X Large Screen -->
@@ -57,24 +57,19 @@
       <picture>
         <!-- Not sure what the browser wants to do with this first one, but it's the largest original -->
         <!--         <source srcset="@/assets/titleImages/splash/frozen-lakeFG.png"> -->
-        <!-- Most compressed -->
-        <source
-          type="image/webp"
-          srcset="@/assets/titleImages/splash/frozen-lakeFG.webp"
-        > 
         <!-- Smallest Screen -->
         <source
-          media="(min-width: 350px)"
+          media="(min-width: 350px) and (max-width: 499px)"
           srcset="@/assets/titleImages/splash/frozen-lakeFG-sm.png"
         >
         <!-- Medium Screen -->
         <source
-          media="(min-width: 500px)"
+          media="(min-width: 500px) and (max-width: 799px)"
           srcset="@/assets/titleImages/splash/frozen-lakeFG-m.png"
         >
         <!-- Large screen -->
         <source
-          media="(min-width: 800px)"
+          media="(min-width: 800px) and (max-width: 1199px)"
           srcset="@/assets/titleImages/splash/frozen-lakeFG-l.png"
         >
         <!-- X Large Screen -->
@@ -82,6 +77,11 @@
           media="(min-width: 1200px)"
           srcset="@/assets/titleImages/splash/frozen-lakeFG-xl.png"
         >
+        <!-- Most compressed -->
+        <source
+          type="image/webp"
+          srcset="@/assets/titleImages/splash/frozen-lakeFG.webp"
+        > 
         <img 
           src="@/assets/titleImages/splash/frozen-lakeFG-xl.png"
           href="@/assets/titleImages/splash/frozen-lakeFG.png"
@@ -104,17 +104,17 @@
         > 
         <!-- Smallest Screen -->
         <source
-          media="(min-width: 350px)"
+          media="(min-width: 350px) and (max-width: 499px)"
           srcset="@/assets/titleImages/splash/people-sm.png"
         >
         <!-- Medium Screen -->
         <source
-          media="(min-width: 500px)"
+          media="(max-width: 500px) and (max-width: 799px)"
           srcset="@/assets/titleImages/splash/people-m.png"
         >
         <!-- Large screen -->
         <source
-          media="(min-width: 800px)"
+          media="(max-width: 800px) and (max-width: 1199px)"
           srcset="@/assets/titleImages/splash/people-l.png"
         >
         <!-- X Large Screen -->
@@ -142,17 +142,17 @@
         > 
         <!-- Smallest Screen -->
         <source
-          media="(min-width: 350px)"
+          media="(min-width: 350px) and (max-width: 499px)"
           srcset="@/assets/titleImages/splash/cloud-sm.png"
         >
         <!-- Medium Screen -->
         <source
-          media="(min-width: 500px)"
+          media="(min-width: 500px) and (max-width: 799px)"
           srcset="@/assets/titleImages/splash/cloud-m.png"
         >
         <!-- Large screen -->
         <source
-          media="(min-width: 800px)"
+          media="(min-width: 800px) and (max-width: 1199px)"
           srcset="@/assets/titleImages/splash/cloud-l.png"
         >
         <!-- X Large Screen -->
@@ -182,17 +182,17 @@
         > 
         <!-- Smallest Screen -->
         <source
-          media="(min-width: 350px)"
+          media="(min-width: 350px) and (max-width: 499px)"
           srcset="@/assets/titleImages/splash/more-clouds-sm.png"
         >
         <!-- Medium Screen -->
         <source
-          media="(min-width: 500px)"
+          media="(min-width: 500px) and (max-width: 799px)"
           srcset="@/assets/titleImages/splash/more-clouds-m.png"
         >
         <!-- Large screen -->
         <source
-          media="(min-width: 800px)"
+          media="(min-width: 800px) and (max-width: 1199px)"
           srcset="@/assets/titleImages/splash/more-clouds.png"
         >
         <!-- X Large Screen -->
@@ -310,6 +310,7 @@ export default {
     object-position: center;
     width: 100%;
     height: 100%;
+    image-rendering: auto;
 }
 #mountains{
     z-index: 10;

--- a/src/components/Splash.vue
+++ b/src/components/Splash.vue
@@ -109,12 +109,12 @@
         >
         <!-- Medium Screen -->
         <source
-          media="(max-width: 500px) and (max-width: 799px)"
+          media="(min-width: 500px) and (max-width: 799px)"
           srcset="@/assets/titleImages/splash/people-m.png"
         >
         <!-- Large screen -->
         <source
-          media="(max-width: 800px) and (max-width: 1199px)"
+          media="(min-width: 800px) and (max-width: 1199px)"
           srcset="@/assets/titleImages/splash/people-l.png"
         >
         <!-- X Large Screen -->


### PR DESCRIPTION
Changes made:
-----------
Description

Changed the source media queries to have a max width as I noticed it was picking the smallest media query for even the largest screen.  That being because the picture element picks the first source media query that matches, so min-width 350px is true when a screen is 2000px wide.  But min-width 350px with a max-width defeats that logic.

Noticed the lake webp isn't the best for larger screen.  I put it at the bottom so the xl image can be picked by the browser.  I noticed a twinge more detail when I did.  

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
