### PR TITLE
edits to mouseover on ridge

### DIFF
--- a/src/components/LineChart.vue
+++ b/src/components/LineChart.vue
@@ -503,7 +503,7 @@ $blue: dodgerblue;
 
 // Copy button style from SWEanim
 .compare {
-  border: 2px solid black;
+  border: 0px solid black;
   display: inline-block;
   width: 80vw;
   max-width: 600px;

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -400,8 +400,9 @@ export default {
         // draw MMD curves
         this.group.append("path")
           .attr("stroke", this.color_mmd)
-          .attr("fill", "transparent")
+          .attr("fill", "this.color_mmd")
           .attr("stroke-opacity", .5)
+          .attr("fill-opacity",.1)
           .attr("d", d => this.line_mmd(d.mmd))
           .attr("stroke-width", "1px")
           .attr("class", function(d) { return d.key })
@@ -418,8 +419,9 @@ export default {
          // draw SWE curves
         this.group.append("path")
           .attr("stroke", this.color_swe)
-          .attr("fill", "transparent")
+          .attr("fill", "this.color_swe")
           .attr("stroke-opacity", .5)
+          .attr("fill-opacity", .1)
           .attr("d", d => this.line_swe(d.swe))
           .attr("stroke-width", "1px")
           .attr("class", function(d) { return d.key })

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -399,8 +399,6 @@ export default {
 
         // draw MMD curves
         this.group.append("path")
-          .attr("fill", this.color_mmd)
-          .attr("fill-opacity", .1)
           .attr("stroke", this.color_mmd)
           .attr("stroke-opacity", .3)
           .attr("d", d => this.line_mmd(d.mmd))
@@ -408,11 +406,9 @@ export default {
           .attr("class", function(d) { return d.key })
           .classed("ridge", true)
           .classed("mmd", true);
-console.log(data_nest)
+
          // draw SWE curves
         this.group.append("path")
-          .attr("fill", this.color_swe)
-          .attr("fill-opacity", .1)
           .attr("stroke", this.color_swe)
           .attr("stroke-opacity", .3)
           .attr("d", d => this.line_swe(d.swe))
@@ -771,13 +767,13 @@ console.log(data_nest)
 
         this.d3.selectAll("g.ridge_2011.curve")
         .transition()
-        .delay(270)
+        .delay(170)
         .duration(500)
         .attr("transform", "translate(0, 0) scale(.49, 1)")
 
          this.d3.selectAll("g.ridge_2012.curve")
         .transition()
-        .delay(250)
+        .delay(150)
         .duration(500)
         .attr("transform", "translate(270, 0) scale(.49, 1)")
 

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -401,7 +401,7 @@ export default {
         this.group.append("path")
           .attr("stroke", this.color_mmd)
           .attr("fill", "transparent")
-          .attr("stroke-opacity", .3)
+          .attr("stroke-opacity", .5)
           .attr("d", d => this.line_mmd(d.mmd))
           .attr("stroke-width", "1px")
           .attr("class", function(d) { return d.key })
@@ -419,7 +419,7 @@ export default {
         this.group.append("path")
           .attr("stroke", this.color_swe)
           .attr("fill", "transparent")
-          .attr("stroke-opacity", .3)
+          .attr("stroke-opacity", .5)
           .attr("d", d => this.line_swe(d.swe))
           .attr("stroke-width", "1px")
           .attr("class", function(d) { return d.key })
@@ -498,7 +498,7 @@ export default {
             .duration(5)
             .attr("stroke-width", "1px")
             .attr("stroke", this.color_mmd)
-            .attr('stroke-opacity', .3)
+            .attr('stroke-opacity', .5)
             .attr("z-index", -1);
 
         self.d3.selectAll('g.curve path.swe.' + data.key)
@@ -506,21 +506,21 @@ export default {
             .duration(5)
             .attr("stroke-width", "1px")
             .attr("stroke", this.color_swe)
-            .attr('stroke-opacity', .3)
+            .attr('stroke-opacity', .5)
             .attr("z-index", -1);
 
              self.d3.selectAll('g.curve path.mmd')
               .transition()
               .attr("stroke-width", "1px")
               .attr("stroke", this.color_mmd)
-              .attr('stroke-opacity', .3)
+              .attr('stroke-opacity', .5)
               .attr("z-index", -1)
 
             self.d3.selectAll('g.curve path.swe')
               .transition()
               .attr("stroke-width", "1px")
               .attr("stroke", this.color_swe)
-              .attr('stroke-opacity', .3)
+              .attr('stroke-opacity', .5)
 
       },
       showSWE(){

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -400,22 +400,32 @@ export default {
         // draw MMD curves
         this.group.append("path")
           .attr("stroke", this.color_mmd)
+          .attr("fill", "transparent")
           .attr("stroke-opacity", .3)
           .attr("d", d => this.line_mmd(d.mmd))
           .attr("stroke-width", "1px")
           .attr("class", function(d) { return d.key })
           .classed("ridge", true)
-          .classed("mmd", true);
+          .classed("mmd", true)
+          .attr('pointer-events', 'visibleStroke')
+          .on("mouseover", function(data_nest) {
+            self.hover(data_nest);
+          })
+          .on("mouseout", function(data_nest){
+            self.hoverOut(data_nest);
+          });
 
          // draw SWE curves
         this.group.append("path")
           .attr("stroke", this.color_swe)
+          .attr("fill", "transparent")
           .attr("stroke-opacity", .3)
           .attr("d", d => this.line_swe(d.swe))
           .attr("stroke-width", "1px")
           .attr("class", function(d) { return d.key })
           .classed("ridge", true)
           .classed("swe", true)
+          .attr('pointer-events', 'visibleStroke')
           .on("mouseover", function(data_nest) {
             self.hover(data_nest);
           })
@@ -454,17 +464,30 @@ export default {
       hover(data){
          const self = this;
 
+          self.d3.selectAll('g.curve path.mmd')
+          .transition()
+            .attr("z-index", -1)
+
+            self.d3.selectAll('g.curve path.swe')
+          .transition()
+            .attr("z-index", -1)
+
+
           self.d3.selectAll('g.curve path.mmd.' + data.key)
             .transition()
-            .duration(50)
+            .duration(5)
             .attr('stroke-width', "2px")
-            .attr('stroke', "blue");
+            .attr('stroke', "darkblue")
+            .attr('stroke-opacity', .8)
+            .attr("z-index", 100);
 
             self.d3.selectAll('g.curve path.swe.' + data.key)
             .transition()
-            .duration(50)
+            .duration(5)
             .attr('stroke-width', "2px")
             .attr('stroke', "black")
+            .attr('stroke-opacity', .8)
+            .attr("z-index", 100);
 
       },
       hoverOut(data){
@@ -472,15 +495,32 @@ export default {
 
           self.d3.selectAll('g.curve path.mmd.' + data.key)
             .transition()
-            .duration(50)
+            .duration(5)
             .attr("stroke-width", "1px")
-            .attr("stroke", this.color_mmd);
+            .attr("stroke", this.color_mmd)
+            .attr('stroke-opacity', .3)
+            .attr("z-index", -1);
 
         self.d3.selectAll('g.curve path.swe.' + data.key)
             .transition()
-            .duration(50)
+            .duration(5)
             .attr("stroke-width", "1px")
-            .attr("stroke", this.color_swe);
+            .attr("stroke", this.color_swe)
+            .attr('stroke-opacity', .3)
+            .attr("z-index", -1);
+
+             self.d3.selectAll('g.curve path.mmd')
+              .transition()
+              .attr("stroke-width", "1px")
+              .attr("stroke", this.color_mmd)
+              .attr('stroke-opacity', .3)
+              .attr("z-index", -1)
+
+            self.d3.selectAll('g.curve path.swe')
+              .transition()
+              .attr("stroke-width", "1px")
+              .attr("stroke", this.color_swe)
+              .attr('stroke-opacity', .3)
 
       },
       showSWE(){
@@ -499,7 +539,7 @@ export default {
           .transition()
           .delay(100)
           .duration(300)
-          .attr("opacity", 0.7)
+          .attr("opacity", 0.5)
         }
 
       },
@@ -519,7 +559,7 @@ export default {
           .transition()
           .delay(100)
           .duration(300)
-          .attr("opacity", 0.7)
+          .attr("opacity", 0.5)
         }
       },
       changePos(){
@@ -782,11 +822,7 @@ export default {
 </script>
 <style lang="scss" scoped>
 $familySerif:  'Noto Serif', serif;
-.gage {
-  color:black;
-  opacity: .6;
 
-}
 .maxWidth {
   width: 90vw;
   margin-left: 5vw;

--- a/src/components/SWEanim.vue
+++ b/src/components/SWEanim.vue
@@ -418,7 +418,6 @@ export default {
           .classed("swe", true)
           .on("mouseover", function(data_nest) {
             self.hover(data_nest);
-            console.log(data_nest)
           })
           .on("mouseout", function(data_nest){
             self.hoverOut(data_nest);
@@ -477,7 +476,7 @@ export default {
             .attr("stroke-width", "1px")
             .attr("stroke", this.color_mmd);
 
-                 self.d3.selectAll('g.curve path.swe.' + data.key)
+        self.d3.selectAll('g.curve path.swe.' + data.key)
             .transition()
             .duration(50)
             .attr("stroke-width", "1px")
@@ -796,13 +795,13 @@ $familySerif:  'Noto Serif', serif;
 }
 
 .compare {
-  border: 2px solid black;
+  border: 0px solid black;
   display: inline-block;
   width: 80vw;
   max-width: 600px;
   font-size: 18px;
   text-align: center;
-  padding: 15px 10px;
+  padding: 15px 0px;
   margin: auto;
   position: relative;
   h4{


### PR DESCRIPTION
Changes made:
-----------
Realized the ridge mouseover wasn't working correctly. Editing this so the right line get selected and avoids glitches. Took out the fill because it was hard to see the ridges in 2/3 views


Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
