### PR TITLE
add UA and GA4 tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,24 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-63TYRT5PQD"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag('js', new Date());
+
+      gtag('config', 'G-63TYRT5PQD');
+    </script>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-78530187-18"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag('js', new Date());
+
+      gtag('config', 'UA-78530187-18');
+    </script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
@@ -16,13 +34,13 @@
       <meta property="og:type" content="website">
       <meta property="og:url" content="https://labs.waterdata.usgs.gov/visualizations/snow-to-flow/index.html#/">
       <meta property="og:title" content="From Snow to Flow">
-      <meta property="og:description" content="what does changing snowmelt mean for water in the western U.S.?"">
+      <meta property="og:description" content="what does changing snowmelt mean for water in the western U.S.?">
       <meta property=" og:image" content="FILL THIS OUT">
       <!-- Twitter -->
       <meta property="twitter:card" content="summary_large_image">
       <meta property="twitter:url" content="https://labs.waterdata.usgs.gov/visualizations/snow-to-flow/index.html#/">
       <meta property="twitter:title" content="From Snow to Flow">
-      <meta property="twitter:description" content="what does changing snowmelt mean for water in the western U.S.?"">
+      <meta property="twitter:description" content="what does changing snowmelt mean for water in the western U.S.?">
       <meta property=" twitter:image" content="FILL THIS OUT">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
 <script type='application/ld+json'>


### PR DESCRIPTION
Changes made:
-----------
Adding google analytics tags for the page. Going to go ahead and merge so I can test that it worked.


Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
