### PR TITLE
Sidebar bug

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -31,9 +31,6 @@
 export default {
     name: "SidebarTwo",
     mounted(){
-        // this.$nextTick(function(){
-        //     this.setDimensions();
-        // });
         window.addEventListener("load", () => this.setDimensions());
     },
     methods:{

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sidebar collapsed">
+  <div class="sidebar collapsed opacity">
     <div class="sidebarContent">
       <div class="titleAndExit">
         <button
@@ -31,16 +31,19 @@
 export default {
     name: "SidebarTwo",
     mounted(){
-        this.$nextTick(function(){
-            this.setDimensions();
-        });
+        // this.$nextTick(function(){
+        //     this.setDimensions();
+        // });
+        window.addEventListener("load", () => this.setDimensions());
     },
     methods:{
         setDimensions(){
             const sidebar = this.$el;
-            const button = this.$el.querySelector(".reveal").getBoundingClientRect();
-            sidebar.style.height = `${button.height}px`;
-            sidebar.style.width = `${button.width}px`;
+            const button = this.$el.querySelector(".reveal")
+            const buttonDimensions = button.getBoundingClientRect();
+            sidebar.style.height = `${buttonDimensions.height}px`;
+            sidebar.style.width = `${buttonDimensions.width}px`;
+            sidebar.classList.remove("opacity");
         },
         toggle(){
             const exit = this.$el.querySelector(".exit");
@@ -71,6 +74,8 @@ $familyMain: 'Public sans', sans-serif;
     will-change: width;
     background: $deepBlue;
     border-radius: 5px;
+    transition: opacity 0.3s;
+
 }
 .titleAndExit{
     position: relative;
@@ -81,6 +86,9 @@ $familyMain: 'Public sans', sans-serif;
 .reveal{
     padding: 5px 10px;
     outline: none;
+}
+.opacity{
+  opacity: 0;
 }
 .exit{
     position: absolute;


### PR DESCRIPTION
Changes made:
-----------
Description

Sidebar buttons on Edge and firefox were cutting off the text occasionally due to a JS function timing issue.  Switching to a window load solves the problem.  Also have the button fades in after load to avoid the awkward huge button to regular size also based on the JS running.  

In short, button text will not be cut off any longer.

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
