### PR TITLE
remove extra space in sidebar content

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -105,6 +105,13 @@ $familyMain: 'Public sans', sans-serif;
 .message{
     background: #fff;
     padding: 10px;
+    *{
+      padding-top: 0;
+      margin-bottom: 10px;
+      &:last-child{
+        margin-bottom: 0;
+      }
+    }
 }
 .collapsed{
     .message{


### PR DESCRIPTION
Changes made:
-----------
Description

Trying to write dynamic CSS so even if we don't put a p tag in the message area the spacing should be the same.  

Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
