### PR TITLE
fix inline buttons in line chart

### DIFF
--- a/src/components/LineChart.vue
+++ b/src/components/LineChart.vue
@@ -535,7 +535,9 @@ sup {
 }
 .butt {
   padding: 5px 5px;
+  margin: 5px 5px;
   cursor: pointer;
+  display: inline-block;
 }
 
 input[name="radiogroup1"] {


### PR DESCRIPTION
Changes made:
-----------
Description


Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
