### PR TITLE
omit people on mobile

### DIFF
--- a/src/components/Splash.vue
+++ b/src/components/Splash.vue
@@ -237,7 +237,7 @@ export default {
                         })
                         .fromTo("#more-clouds", {yPercent: 50}, {yPercent: -40}, 0)
                         .fromTo("#clouds", {yPercent: 30}, {yPercent: -10}, 0)
-                        .fromTo("#people", {yPercent: 17}, {yPercent: -11}, 0)
+                        //.fromTo("#people", {yPercent: 17}, {yPercent: -11}, 0)
                         .fromTo("#water", {yPercent: 25}, {yPercent: -10}, 0)
                         .fromTo("#mountains", {yPercent: 30}, {yPercent: 0}, 0)
                     },


### PR DESCRIPTION
Changes made:
-----------
Description


Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
