### PR TITLE
fix readme image url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # From Snow to Flow Visualization
 
-![A screencapture of the Snow to Flow header, which shows an abstract collage of snowy mountains and a frozen lake under a series of snow and discharge line charts.](https://labs-beta.waterdata.usgs.gov/visualizations/snow-to-flow/SnowToFlowCover.jpg)
+![A screencapture of the Snow to Flow header, which shows an abstract collage of snowy mountains and a frozen lake under a series of snow and discharge line charts.](https://github.com/USGS-VIZLAB/snow-to-flow/blob/main/public/SnowToFlowCover.jpg)
 
 See the page live: https://labs.waterdata.usgs.gov/visualizations/snow-to-flow/index.html#/
 


### PR DESCRIPTION
Changes made:
-----------
Description


Testing:
----------------------------
Before making this pull request, I:
- [ ] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
