### PR TITLE
add margin so top of byline isn't cut off

### DIFF
--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -62,6 +62,6 @@ export default {
 <style lang="scss" scoped>
   #byline {
     font-weight: 400;
-    margin-bottom: 64px;
+    margin: 64px 0 64px 0;
   }
 </style>


### PR DESCRIPTION
Changes made:
-----------
Tiny MR to fix the byline - it was being cut off:

![image](https://github.com/DOI-USGS/snow-to-flow/assets/54007288/23310d92-d48c-4804-8d52-ea73364ae4a6)

Now:

![image](https://github.com/DOI-USGS/snow-to-flow/assets/54007288/29b80cb2-c43f-4ff8-87ae-2d2d8b344ed5)



Testing:
----------------------------
Before making this pull request, I:
- [x] Cleaned the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Made sure all tests run
- [ ] Ran WAVE plugin 508 compliance tool

I can confirm this has been checked on:
- [ ] Chrome
- [ ] Safari
- [x] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)
